### PR TITLE
Update classes for Wall of Light

### DIFF
--- a/Data/Spells.json
+++ b/Data/Spells.json
@@ -13953,7 +13953,9 @@
     {
         "casting_time": "1 action",
         "classes": [
-            "Sorcerer"
+            "Sorcerer",
+            "Warlock",
+            "Wizard"
         ],
         "components": [
             "V",


### PR DESCRIPTION
This PR updates the classes for Wall of Light - both Warlock and Wizard were missing.