### PR TITLE
Add functionality to cast a spell

### DIFF
--- a/Spellbook.xcodeproj/project.pbxproj
+++ b/Spellbook.xcodeproj/project.pbxproj
@@ -138,6 +138,8 @@
 		8ED0B9382431392700A085F4 /* NameDisplayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ED0B9372431392700A085F4 /* NameDisplayable.swift */; };
 		8EEA28FD297C23D8004971AD /* SpellFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EEA28FC297C23D8004971AD /* SpellFilter.swift */; };
 		8EEAFCCA2645FB4C00A05D01 /* LegacyProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EEAFCC92645FB4C00A05D01 /* LegacyProfileTests.swift */; };
+		8EEDC3E22ADA69170045D002 /* HigherLevelSlotController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EEDC3E12ADA69170045D002 /* HigherLevelSlotController.swift */; };
+		8EEDC3E42AE739A60045D002 /* ConfirmNextAvailableCastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EEDC3E32AE739A50045D002 /* ConfirmNextAvailableCastController.swift */; };
 		8EF6EF0B264668F60059BCE8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF6EF0A264668F60059BCE8 /* Version.swift */; };
 		8EF6EF0D26485A2E0059BCE8 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF6EF0C26485A2E0059BCE8 /* VersionTests.swift */; };
 /* End PBXBuildFile section */
@@ -295,6 +297,8 @@
 		8ED0B9372431392700A085F4 /* NameDisplayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameDisplayable.swift; sourceTree = "<group>"; };
 		8EEA28FC297C23D8004971AD /* SpellFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpellFilter.swift; sourceTree = "<group>"; };
 		8EEAFCC92645FB4C00A05D01 /* LegacyProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyProfileTests.swift; sourceTree = "<group>"; };
+		8EEDC3E12ADA69170045D002 /* HigherLevelSlotController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HigherLevelSlotController.swift; sourceTree = "<group>"; };
+		8EEDC3E32AE739A50045D002 /* ConfirmNextAvailableCastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmNextAvailableCastController.swift; sourceTree = "<group>"; };
 		8EF6EF0A264668F60059BCE8 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		8EF6EF0C26485A2E0059BCE8 /* VersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -359,6 +363,7 @@
 			isa = PBXGroup;
 			children = (
 				397EE96C21ACA86400B116B0 /* Main.storyboard */,
+				8EEDC3E12ADA69170045D002 /* HigherLevelSlotController.swift */,
 				8E07AE0C2A0F708700C0487B /* ImportCharacterController.swift */,
 				8EB3692129405EAB00856738 /* SpellbookReducers.swift */,
 				8EB3691D293F123900856738 /* AppReducer.swift */,
@@ -384,6 +389,7 @@
 				8E6148D7241991C100842A18 /* Constants.swift */,
 				8E6148C3241991C000842A18 /* Controllers.swift */,
 				8E6148A5241991BF00842A18 /* DeletionPromptController.swift */,
+				8EEDC3E32AE739A50045D002 /* ConfirmNextAvailableCastController.swift */,
 				8E61489E241991BE00842A18 /* Duration.swift */,
 				8E6148DE241991C100842A18 /* EnumMap.swift */,
 				8E6148C5241991C000842A18 /* EnumUtilities.swift */,
@@ -772,9 +778,11 @@
 				8E6E2B8228E9FE4A00AA6483 /* SpellSlotsController.swift in Sources */,
 				8EB3691E293F123900856738 /* AppReducer.swift in Sources */,
 				8E6148F8241991C200842A18 /* StringUtils.swift in Sources */,
+				8EEDC3E22ADA69170045D002 /* HigherLevelSlotController.swift in Sources */,
 				8E614927241991C200842A18 /* SpellBuilder.swift in Sources */,
 				8E02F76224345F6200A3050C /* YesNo.swift in Sources */,
 				8E07AE0D2A0F708700C0487B /* ImportCharacterController.swift in Sources */,
+				8EEDC3E42AE739A60045D002 /* ConfirmNextAvailableCastController.swift in Sources */,
 				8EEA28FD297C23D8004971AD /* SpellFilter.swift in Sources */,
 				8E614916241991C200842A18 /* SideMenuController.swift in Sources */,
 				8E74FA5A29EBD7D900E13B91 /* SpellSlotsManagerCell.swift in Sources */,

--- a/Spellbook/AppDelegate.swift
+++ b/Spellbook/AppDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import ReSwift
 
 typealias SpellbookStore = Store<SpellbookAppState>
-let store = SpellbookStore(reducer: appReducer, state: nil, middleware: [switchProfileMiddleware, switchProfileByNameMiddleware, createProfileMiddleware, saveProfileMiddleware, saveCurrentProfileMiddleware, deleteProfileMiddleware, deleteProfileByNameMiddleware])
+let store = SpellbookStore(reducer: appReducer, state: nil, middleware: [switchProfileMiddleware, switchProfileByNameMiddleware, createProfileMiddleware, saveProfileMiddleware, saveCurrentProfileMiddleware, deleteProfileMiddleware, deleteProfileByNameMiddleware, makeToastMiddleware])
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Spellbook/AppReducer.swift
+++ b/Spellbook/AppReducer.swift
@@ -168,6 +168,9 @@ func specificActionReducer(action: Action, state: inout SpellbookAppState) -> Sp
     case let action as SaveSettingsAction:
         return saveSettingsReducer(action: action, state: &state)
 
+    case let action as CastSpellAction:
+        return castSpellReducer(action: action, state: state)
+
     // If we somehow get here, just do nothing
     default:
         return state

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -501,6 +501,14 @@
                                                 </constraints>
                                                 <state key="normal" image="book_empty.png"/>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qMf-rX-l1X" userLabel="Cast Button">
+                                                <rect key="frame" x="366" y="6" width="32" height="35"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="Cast">
+                                                    <color key="titleColor" systemColor="labelColor"/>
+                                                </state>
+                                            </button>
                                         </subviews>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
@@ -513,6 +521,7 @@
                                             <constraint firstItem="z3p-02-z1G" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.13" id="6mi-9w-6p9"/>
                                             <constraint firstItem="MBx-OV-kFQ" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="71b-2R-D0o"/>
                                             <constraint firstItem="LO2-Vv-zrI" firstAttribute="top" secondItem="MBx-OV-kFQ" secondAttribute="bottom" constant="2" id="8xr-Zo-SgC"/>
+                                            <constraint firstItem="qMf-rX-l1X" firstAttribute="top" relation="greaterThanOrEqual" secondItem="f6W-mZ-pXE" secondAttribute="bottom" constant="3" id="92H-bv-Tnh"/>
                                             <constraint firstItem="pc4-lp-KCl" firstAttribute="top" secondItem="RLp-JA-JL3" secondAttribute="bottom" constant="2" id="BSq-yV-P1q"/>
                                             <constraint firstItem="RLp-JA-JL3" firstAttribute="top" secondItem="eMW-F5-hmt" secondAttribute="bottom" constant="2" id="BbM-YP-TQ1"/>
                                             <constraint firstItem="yfg-mz-Cj6" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="D9U-ca-A2c"/>
@@ -540,6 +549,7 @@
                                             <constraint firstItem="7Lk-KK-W3S" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="dHb-v6-bje"/>
                                             <constraint firstItem="7Lk-KK-W3S" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="dJ1-0n-Bjg"/>
                                             <constraint firstItem="y43-NE-UnZ" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="dU9-Ux-a9b"/>
+                                            <constraint firstItem="qMf-rX-l1X" firstAttribute="centerX" secondItem="f6W-mZ-pXE" secondAttribute="centerX" id="fdo-qZ-j2g"/>
                                             <constraint firstItem="31Y-hW-A43" firstAttribute="top" secondItem="AnF-D5-EEE" secondAttribute="bottom" id="frZ-29-dsB"/>
                                             <constraint firstItem="eMW-F5-hmt" firstAttribute="top" secondItem="xTV-VH-ZcY" secondAttribute="top" constant="1" id="gVE-Jr-UFL"/>
                                             <constraint firstItem="31Y-hW-A43" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="hkg-yA-02R"/>
@@ -580,6 +590,7 @@
                     </view>
                     <connections>
                         <outlet property="backgroundView" destination="ypa-xU-HWY" id="FH7-hP-bh1"/>
+                        <outlet property="castButton" destination="qMf-rX-l1X" id="OWI-Bm-JqM"/>
                         <outlet property="castingTimeLabel" destination="LO2-Vv-zrI" id="w0d-z1-cd6"/>
                         <outlet property="classesLabel" destination="yfg-mz-Cj6" id="nrb-3x-ny7"/>
                         <outlet property="componentsLabel" destination="hUT-AL-0TC" id="nxF-Sg-fcq"/>
@@ -1253,7 +1264,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <containerView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YnO-eH-2iK">
-                                <rect key="frame" x="87" y="384" width="240" height="128"/>
+                                <rect key="frame" x="87" y="383" width="238" height="127"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1324,14 +1335,14 @@
             <objects>
                 <viewController id="526-HG-Tzy" customClass="StatusFilterController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Jzb-0h-mv9" customClass="UITableView">
-                        <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                        <rect key="frame" x="0.0" y="0.0" width="238" height="127"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="statusMenuCell" translatesAutoresizingMaskIntoConstraints="NO" id="hC5-Lg-NpH" customClass="SideMenuCell" customModule="Spellbook" customModuleProvider="target">
                                 <rect key="frame" x="-68" y="42" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hC5-Lg-NpH" id="CKz-Hx-6IP">
-                                    <rect key="frame" x="0.0" y="0.0" width="189" height="44"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -1406,7 +1417,7 @@
                                                             <textInputTraits key="textInputTraits"/>
                                                         </textField>
                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="n0U-Lk-Dt4" userLabel="First Level Arrow" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                            <rect key="frame" x="84" y="7" width="18" height="22"/>
+                                                            <rect key="frame" x="84" y="6" width="24" height="24"/>
                                                             <state key="normal" image="down_arrow.png"/>
                                                         </button>
                                                     </subviews>
@@ -1691,7 +1702,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="9m7-IC-edr" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="9m7-IC-edr" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Wy-Y7-3R4">
@@ -1749,7 +1760,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-JQ-hq6" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-JQ-hq6" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1na-Fe-aSv">
@@ -1839,7 +1850,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="9Av-vT-BMJ" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="9Av-vT-BMJ" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="kYh-hu-pH6">
@@ -1898,7 +1909,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="eJH-NJ-9aR" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="eJH-NJ-9aR" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="hCS-XO-M3z">
@@ -1985,7 +1996,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="zjA-aV-cOq" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="zjA-aV-cOq" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="ld3-gq-3Nv">
@@ -2136,7 +2147,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="LR8-S2-cAX" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="LR8-S2-cAX" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eyw-BM-ZK5">
@@ -2258,7 +2269,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="ivf-rg-qoA" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="ivf-rg-qoA" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="1en-JT-doz">
@@ -2372,7 +2383,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="l2R-a5-9D9" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="l2R-a5-9D9" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="gfd-Qa-VSe">
@@ -2482,7 +2493,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="XWr-P7-zGZ" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="XWr-P7-zGZ" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="yeu-9c-2EZ">
@@ -2626,7 +2637,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="pZE-d0-NmF" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="pZE-d0-NmF" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="Rbu-PW-9Tz">
@@ -2765,7 +2776,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="Hpd-Dh-ert" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="Hpd-Dh-ert" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="ze1-FN-cRj">

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -846,10 +846,10 @@
             </objects>
             <point key="canvasLocation" x="4540.579710144928" y="-193.52678571428569"/>
         </scene>
-        <!--Higher Level Slot Controller-->
+        <!--Higher Level Slot Controller old-->
         <scene sceneID="Uyg-Ic-rFW">
             <objects>
-                <viewController storyboardIdentifier="higherLevelSlotDialog" useStoryboardIdentifierAsRestorationIdentifier="YES" id="GpO-Pl-HcB" customClass="HigherLevelSlotController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="higherLevelSlotDialogOld" modalPresentationStyle="overCurrentContext" useStoryboardIdentifierAsRestorationIdentifier="YES" id="GpO-Pl-HcB" userLabel="Higher Level Slot Controller old" customClass="HigherLevelSlotController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="GAW-fg-wte">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1020,9 +1020,13 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="3ts-vc-Ye6" firstAttribute="trailing" secondItem="YLa-Ne-v4H" secondAttribute="trailing" id="1b9-MK-Sig"/>
+                            <constraint firstItem="q0E-8I-oeP" firstAttribute="trailing" secondItem="3ts-vc-Ye6" secondAttribute="trailing" id="42m-fk-exH"/>
+                            <constraint firstItem="q0E-8I-oeP" firstAttribute="top" secondItem="51v-iM-lTt" secondAttribute="top" id="Kur-cC-eDx"/>
                             <constraint firstItem="3ts-vc-Ye6" firstAttribute="trailing" secondItem="q0E-8I-oeP" secondAttribute="trailing" id="MJi-5P-xqQ"/>
                             <constraint firstItem="YLa-Ne-v4H" firstAttribute="top" secondItem="3ts-vc-Ye6" secondAttribute="top" id="NhU-Rg-gDt"/>
+                            <constraint firstItem="q0E-8I-oeP" firstAttribute="leading" secondItem="3ts-vc-Ye6" secondAttribute="leading" id="ORO-zZ-Ba0"/>
                             <constraint firstItem="q0E-8I-oeP" firstAttribute="leading" secondItem="3ts-vc-Ye6" secondAttribute="leading" id="XIb-Q1-VYM"/>
+                            <constraint firstItem="q0E-8I-oeP" firstAttribute="bottom" secondItem="3ts-vc-Ye6" secondAttribute="bottom" id="iYM-hD-pp3"/>
                             <constraint firstItem="YLa-Ne-v4H" firstAttribute="leading" secondItem="3ts-vc-Ye6" secondAttribute="leading" id="ish-sL-syY"/>
                             <constraint firstItem="q0E-8I-oeP" firstAttribute="bottom" secondItem="51v-iM-lTt" secondAttribute="bottom" id="jbD-Cs-Wrv"/>
                             <constraint firstItem="q0E-8I-oeP" firstAttribute="top" secondItem="51v-iM-lTt" secondAttribute="top" id="qEs-YQ-kkz"/>
@@ -1133,6 +1137,85 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="06p-7L-Sgg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="5673.177903801723" y="23.317920918367342"/>
+        </scene>
+        <!--Higher Level Slot Controller-->
+        <scene sceneID="NLX-iC-gpt">
+            <objects>
+                <viewController storyboardIdentifier="higherLevelSlotDialog" modalPresentationStyle="overCurrentContext" id="Lr5-L7-Can" customClass="HigherLevelSlotController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="6LT-Bz-B28">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TX4-om-EeB" userLabel="Content View">
+                                <rect key="frame" x="0.0" y="44" width="414" height="356"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select Slot Level" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8jU-U7-zqg" userLabel="Higher Level Title">
+                                        <rect key="frame" x="67" y="0.0" width="280" height="47"/>
+                                        <fontDescription key="fontDescription" name="CloisterBlack-Light" family="Cloister Black" pointSize="40"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Slot level:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ByY-tq-dHs" userLabel="Slot Level Label">
+                                        <rect key="frame" x="5" y="52" width="73.333333333333329" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b9q-J4-0cv" userLabel="Cancel Button">
+                                        <rect key="frame" x="309" y="87.666666666666657" width="48" height="30"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Cancel">
+                                            <color key="titleColor" name="DefaultFontColor"/>
+                                        </state>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F1B-yn-h71" userLabel="Cast Button">
+                                        <rect key="frame" x="372" y="87.666666666666657" width="32" height="30"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Cast">
+                                            <color key="titleColor" name="DefaultFontColor"/>
+                                        </state>
+                                    </button>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="f7c-NG-8CO" userLabel="Slot Level Chooser">
+                                        <rect key="frame" x="81.333333333333329" y="45.666666666666671" width="32" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="ByY-tq-dHs" firstAttribute="top" secondItem="8jU-U7-zqg" secondAttribute="bottom" constant="5" id="DDZ-6F-R37"/>
+                                    <constraint firstItem="f7c-NG-8CO" firstAttribute="leading" secondItem="ByY-tq-dHs" secondAttribute="trailing" constant="3" id="GCw-cz-P0l"/>
+                                    <constraint firstItem="F1B-yn-h71" firstAttribute="top" secondItem="f7c-NG-8CO" secondAttribute="bottom" constant="8" id="HnK-OH-hre"/>
+                                    <constraint firstItem="b9q-J4-0cv" firstAttribute="top" secondItem="f7c-NG-8CO" secondAttribute="bottom" constant="8" id="LZs-zk-3jE"/>
+                                    <constraint firstAttribute="trailing" secondItem="F1B-yn-h71" secondAttribute="trailing" constant="10" id="d9p-WZ-Bhd"/>
+                                    <constraint firstItem="F1B-yn-h71" firstAttribute="leading" secondItem="b9q-J4-0cv" secondAttribute="trailing" constant="15" id="dju-Le-TZH"/>
+                                    <constraint firstItem="8jU-U7-zqg" firstAttribute="centerX" secondItem="TX4-om-EeB" secondAttribute="centerX" id="fCW-Ls-4fG"/>
+                                    <constraint firstItem="f7c-NG-8CO" firstAttribute="centerY" secondItem="ByY-tq-dHs" secondAttribute="centerY" id="oEU-b3-e4q"/>
+                                    <constraint firstItem="8jU-U7-zqg" firstAttribute="top" secondItem="TX4-om-EeB" secondAttribute="top" id="svF-H7-mLE"/>
+                                    <constraint firstItem="ByY-tq-dHs" firstAttribute="leading" secondItem="TX4-om-EeB" secondAttribute="leading" constant="5" id="tAR-XG-P1n"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="rhV-sZ-DLl"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="TX4-om-EeB" firstAttribute="top" secondItem="rhV-sZ-DLl" secondAttribute="top" id="9Pg-HA-Dnj"/>
+                            <constraint firstItem="rhV-sZ-DLl" firstAttribute="trailing" secondItem="TX4-om-EeB" secondAttribute="trailing" id="IY2-Wp-KMW"/>
+                            <constraint firstItem="TX4-om-EeB" firstAttribute="leading" secondItem="rhV-sZ-DLl" secondAttribute="leading" id="TZL-e7-31M"/>
+                            <constraint firstItem="rhV-sZ-DLl" firstAttribute="bottom" secondItem="TX4-om-EeB" secondAttribute="bottom" id="hpu-fV-sRg"/>
+                        </constraints>
+                    </view>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="414" height="400"/>
+                    <connections>
+                        <outlet property="cancelButton" destination="b9q-J4-0cv" id="emY-pg-Sgb"/>
+                        <outlet property="castButton" destination="F1B-yn-h71" id="XPV-kW-M41"/>
+                        <outlet property="slotLevelChooser" destination="f7c-NG-8CO" id="w0w-25-Cna"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vti-8N-CsL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="6430" y="-665"/>
         </scene>
         <!--Deletion Prompt Controller-->
         <scene sceneID="Tbl-02-dyn">

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -571,8 +571,10 @@
                                                 <state key="normal" image="book_empty.png"/>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qMf-rX-l1X" userLabel="Cast Button">
-                                                <rect key="frame" x="366" y="6" width="32" height="35"/>
+                                                <rect key="frame" x="355.66666666666669" y="6" width="53" height="35"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                <inset key="contentEdgeInsets" minX="8" minY="8" maxX="8" maxY="8"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 <state key="normal" title="Cast">
                                                     <color key="titleColor" systemColor="labelColor"/>
@@ -1165,9 +1167,9 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="f7c-NG-8CO" userLabel="Slot Level Chooser">
-                                        <rect key="frame" x="81.333333333333329" y="45.666666666666671" width="32" height="34"/>
+                                        <rect key="frame" x="81.333333333333329" y="45.666666666666671" width="33" height="34"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b9q-J4-0cv" userLabel="Cancel Button">

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -1146,6 +1146,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="f1B-rQ-au5" userLabel="Background View">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
+                            </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TX4-om-EeB" userLabel="Content View">
                                 <rect key="frame" x="0.0" y="44" width="414" height="356"/>
                                 <subviews>
@@ -1161,6 +1164,12 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="f7c-NG-8CO" userLabel="Slot Level Chooser">
+                                        <rect key="frame" x="81.333333333333329" y="45.666666666666671" width="32" height="34"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b9q-J4-0cv" userLabel="Cancel Button">
                                         <rect key="frame" x="309" y="87.666666666666657" width="48" height="30"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -1175,13 +1184,8 @@
                                             <color key="titleColor" name="DefaultFontColor"/>
                                         </state>
                                     </button>
-                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="f7c-NG-8CO" userLabel="Slot Level Chooser">
-                                        <rect key="frame" x="81.333333333333329" y="45.666666666666671" width="32" height="34"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits"/>
-                                    </textField>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="ByY-tq-dHs" firstAttribute="top" secondItem="8jU-U7-zqg" secondAttribute="bottom" constant="5" id="DDZ-6F-R37"/>
                                     <constraint firstItem="f7c-NG-8CO" firstAttribute="leading" secondItem="ByY-tq-dHs" secondAttribute="trailing" constant="3" id="GCw-cz-P0l"/>
@@ -1200,9 +1204,13 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="TX4-om-EeB" firstAttribute="top" secondItem="rhV-sZ-DLl" secondAttribute="top" id="9Pg-HA-Dnj"/>
+                            <constraint firstItem="f1B-rQ-au5" firstAttribute="top" secondItem="6LT-Bz-B28" secondAttribute="top" id="E8i-F3-5lH"/>
                             <constraint firstItem="rhV-sZ-DLl" firstAttribute="trailing" secondItem="TX4-om-EeB" secondAttribute="trailing" id="IY2-Wp-KMW"/>
                             <constraint firstItem="TX4-om-EeB" firstAttribute="leading" secondItem="rhV-sZ-DLl" secondAttribute="leading" id="TZL-e7-31M"/>
+                            <constraint firstItem="f1B-rQ-au5" firstAttribute="bottom" secondItem="6LT-Bz-B28" secondAttribute="bottom" id="VhI-ZA-VUr"/>
+                            <constraint firstItem="f1B-rQ-au5" firstAttribute="leading" secondItem="rhV-sZ-DLl" secondAttribute="leading" id="ahI-in-NxO"/>
                             <constraint firstItem="rhV-sZ-DLl" firstAttribute="bottom" secondItem="TX4-om-EeB" secondAttribute="bottom" id="hpu-fV-sRg"/>
+                            <constraint firstItem="rhV-sZ-DLl" firstAttribute="trailing" secondItem="f1B-rQ-au5" secondAttribute="trailing" id="ok4-Ps-QIn"/>
                         </constraints>
                     </view>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -16,6 +16,74 @@
         </array>
     </customFonts>
     <scenes>
+        <!--Confirm Next Available Cast Controller-->
+        <scene sceneID="MII-ea-ICI">
+            <objects>
+                <viewController restorationIdentifier="confirmNextAvailableCast" id="9Fa-y1-h1a" customClass="ConfirmNextAvailableCastController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="P7I-Df-fYZ">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="KwL-1f-CAa" userLabel="Background View">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HSB-ib-m5H" userLabel="Available Cast Title">
+                                <rect key="frame" x="186" y="44" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V8a-ag-tIE" userLabel="Available Cast Message">
+                                <rect key="frame" x="0.0" y="67" width="414" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eFG-sf-NX6" userLabel="Yes Button">
+                                <rect key="frame" x="169" y="182" width="75" height="35"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="Button">
+                                    <color key="titleColor" name="DefaultFontColor"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="75v-2M-5fL" userLabel="No Button">
+                                <rect key="frame" x="169" y="182" width="75" height="35"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="Button">
+                                    <color key="titleColor" name="DefaultFontColor"/>
+                                </state>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="9br-on-Fyr"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="9br-on-Fyr" firstAttribute="trailing" secondItem="eFG-sf-NX6" secondAttribute="trailing" constant="10" id="9ks-ja-NUz"/>
+                            <constraint firstAttribute="bottom" secondItem="KwL-1f-CAa" secondAttribute="bottom" id="H1i-9w-QBk"/>
+                            <constraint firstItem="9br-on-Fyr" firstAttribute="trailing" secondItem="KwL-1f-CAa" secondAttribute="trailing" id="IM0-BX-3Md"/>
+                            <constraint firstItem="HSB-ib-m5H" firstAttribute="centerX" secondItem="9br-on-Fyr" secondAttribute="centerX" id="KqL-NM-ojZ"/>
+                            <constraint firstItem="HSB-ib-m5H" firstAttribute="top" secondItem="9br-on-Fyr" secondAttribute="top" id="RR5-yp-CYT"/>
+                            <constraint firstItem="75v-2M-5fL" firstAttribute="centerY" secondItem="eFG-sf-NX6" secondAttribute="centerY" id="Xvc-dz-PGd"/>
+                            <constraint firstItem="KwL-1f-CAa" firstAttribute="leading" secondItem="9br-on-Fyr" secondAttribute="leading" id="Zwk-KQ-fBq"/>
+                            <constraint firstItem="V8a-ag-tIE" firstAttribute="leading" secondItem="9br-on-Fyr" secondAttribute="leading" id="hdN-pl-iKm"/>
+                            <constraint firstItem="9br-on-Fyr" firstAttribute="trailing" secondItem="V8a-ag-tIE" secondAttribute="trailing" id="jmI-Ed-5sn"/>
+                            <constraint firstItem="eFG-sf-NX6" firstAttribute="top" secondItem="V8a-ag-tIE" secondAttribute="bottom" constant="8" id="nLE-52-sk7"/>
+                            <constraint firstItem="eFG-sf-NX6" firstAttribute="leading" secondItem="75v-2M-5fL" secondAttribute="trailing" constant="15" id="wo5-vy-C1p"/>
+                            <constraint firstItem="KwL-1f-CAa" firstAttribute="top" secondItem="P7I-Df-fYZ" secondAttribute="top" id="wzQ-3s-g9G"/>
+                            <constraint firstItem="V8a-ag-tIE" firstAttribute="top" secondItem="HSB-ib-m5H" secondAttribute="bottom" constant="2" id="zeF-J5-zZ8"/>
+                        </constraints>
+                    </view>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="414" height="400"/>
+                    <connections>
+                        <outlet property="availableCastMessage" destination="V8a-ag-tIE" id="pxZ-gg-vZc"/>
+                        <outlet property="noButton" destination="75v-2M-5fL" id="UxV-fs-YOe"/>
+                        <outlet property="yesButton" destination="eFG-sf-NX6" id="54a-EB-1tu"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="uWj-vZ-dEg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-2084" y="-1055"/>
+        </scene>
         <!--Spell Slots Manager Controller-->
         <scene sceneID="zsG-WN-av0">
             <objects>
@@ -508,6 +576,14 @@
                                                 <state key="normal" title="Cast">
                                                     <color key="titleColor" systemColor="labelColor"/>
                                                 </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                                                        <integer key="value" value="1"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.borderRadius">
+                                                        <integer key="value" value="5"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
                                             </button>
                                         </subviews>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -772,7 +848,7 @@
         <!--Higher Level Slot Controller-->
         <scene sceneID="Uyg-Ic-rFW">
             <objects>
-                <viewController modalPresentationStyle="overCurrentContext" id="GpO-Pl-HcB" customClass="HigherLevelSlotController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="higherLevelSlotDialog" modalPresentationStyle="overCurrentContext" id="GpO-Pl-HcB" customClass="HigherLevelSlotController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="GAW-fg-wte">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -19,7 +19,7 @@
         <!--Confirm Next Available Cast Controller-->
         <scene sceneID="MII-ea-ICI">
             <objects>
-                <viewController restorationIdentifier="confirmNextAvailableCast" id="9Fa-y1-h1a" customClass="ConfirmNextAvailableCastController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="confirmNextAvailableCast" id="9Fa-y1-h1a" customClass="ConfirmNextAvailableCastController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="P7I-Df-fYZ">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -27,14 +27,8 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="KwL-1f-CAa" userLabel="Background View">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HSB-ib-m5H" userLabel="Available Cast Title">
-                                <rect key="frame" x="186" y="44" width="42" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V8a-ag-tIE" userLabel="Available Cast Message">
-                                <rect key="frame" x="0.0" y="67" width="414" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V8a-ag-tIE" userLabel="Available Cast Message">
+                                <rect key="frame" x="5" y="52" width="404" height="20.333333333333329"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -42,17 +36,23 @@
                             <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eFG-sf-NX6" userLabel="Yes Button">
                                 <rect key="frame" x="169" y="182" width="75" height="35"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" title="Button">
+                                <state key="normal" title="Yes">
                                     <color key="titleColor" name="DefaultFontColor"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="75v-2M-5fL" userLabel="No Button">
-                                <rect key="frame" x="169" y="182" width="75" height="35"/>
+                                <rect key="frame" x="86" y="153" width="75" height="35"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" title="Button">
+                                <state key="normal" title="No">
                                     <color key="titleColor" name="DefaultFontColor"/>
                                 </state>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Use Higher Slot?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WWx-wL-bbp" userLabel="Available Cast Title">
+                                <rect key="frame" x="44" y="-7" width="325" height="93"/>
+                                <fontDescription key="fontDescription" name="CloisterBlack-Light" family="Cloister Black" pointSize="40"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="9br-on-Fyr"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -60,16 +60,17 @@
                             <constraint firstItem="9br-on-Fyr" firstAttribute="trailing" secondItem="eFG-sf-NX6" secondAttribute="trailing" constant="10" id="9ks-ja-NUz"/>
                             <constraint firstAttribute="bottom" secondItem="KwL-1f-CAa" secondAttribute="bottom" id="H1i-9w-QBk"/>
                             <constraint firstItem="9br-on-Fyr" firstAttribute="trailing" secondItem="KwL-1f-CAa" secondAttribute="trailing" id="IM0-BX-3Md"/>
-                            <constraint firstItem="HSB-ib-m5H" firstAttribute="centerX" secondItem="9br-on-Fyr" secondAttribute="centerX" id="KqL-NM-ojZ"/>
-                            <constraint firstItem="HSB-ib-m5H" firstAttribute="top" secondItem="9br-on-Fyr" secondAttribute="top" id="RR5-yp-CYT"/>
+                            <constraint firstItem="WWx-wL-bbp" firstAttribute="centerX" secondItem="P7I-Df-fYZ" secondAttribute="centerX" id="JhP-9W-u1u"/>
+                            <constraint firstItem="V8a-ag-tIE" firstAttribute="top" secondItem="WWx-wL-bbp" secondAttribute="bottom" constant="5" id="Lqw-b3-s2K"/>
                             <constraint firstItem="75v-2M-5fL" firstAttribute="centerY" secondItem="eFG-sf-NX6" secondAttribute="centerY" id="Xvc-dz-PGd"/>
+                            <constraint firstItem="9br-on-Fyr" firstAttribute="bottom" secondItem="eFG-sf-NX6" secondAttribute="bottom" constant="5" id="YgE-Ky-XUw"/>
                             <constraint firstItem="KwL-1f-CAa" firstAttribute="leading" secondItem="9br-on-Fyr" secondAttribute="leading" id="Zwk-KQ-fBq"/>
-                            <constraint firstItem="V8a-ag-tIE" firstAttribute="leading" secondItem="9br-on-Fyr" secondAttribute="leading" id="hdN-pl-iKm"/>
-                            <constraint firstItem="9br-on-Fyr" firstAttribute="trailing" secondItem="V8a-ag-tIE" secondAttribute="trailing" id="jmI-Ed-5sn"/>
+                            <constraint firstItem="V8a-ag-tIE" firstAttribute="leading" secondItem="9br-on-Fyr" secondAttribute="leading" constant="5" id="hdN-pl-iKm"/>
+                            <constraint firstItem="9br-on-Fyr" firstAttribute="trailing" secondItem="V8a-ag-tIE" secondAttribute="trailing" constant="5" id="jmI-Ed-5sn"/>
                             <constraint firstItem="eFG-sf-NX6" firstAttribute="top" secondItem="V8a-ag-tIE" secondAttribute="bottom" constant="8" id="nLE-52-sk7"/>
-                            <constraint firstItem="eFG-sf-NX6" firstAttribute="leading" secondItem="75v-2M-5fL" secondAttribute="trailing" constant="15" id="wo5-vy-C1p"/>
+                            <constraint firstItem="eFG-sf-NX6" firstAttribute="leading" secondItem="75v-2M-5fL" secondAttribute="trailing" constant="25" id="wo5-vy-C1p"/>
                             <constraint firstItem="KwL-1f-CAa" firstAttribute="top" secondItem="P7I-Df-fYZ" secondAttribute="top" id="wzQ-3s-g9G"/>
-                            <constraint firstItem="V8a-ag-tIE" firstAttribute="top" secondItem="HSB-ib-m5H" secondAttribute="bottom" constant="2" id="zeF-J5-zZ8"/>
+                            <constraint firstItem="WWx-wL-bbp" firstAttribute="top" secondItem="P7I-Df-fYZ" secondAttribute="top" id="y3k-Pa-IGm"/>
                         </constraints>
                     </view>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
@@ -82,7 +83,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uWj-vZ-dEg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-2084" y="-1055"/>
+            <point key="canvasLocation" x="-2084.057971014493" y="-1056.0267857142858"/>
         </scene>
         <!--Spell Slots Manager Controller-->
         <scene sceneID="zsG-WN-av0">
@@ -848,12 +849,12 @@
         <!--Higher Level Slot Controller-->
         <scene sceneID="Uyg-Ic-rFW">
             <objects>
-                <viewController storyboardIdentifier="higherLevelSlotDialog" modalPresentationStyle="overCurrentContext" id="GpO-Pl-HcB" customClass="HigherLevelSlotController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="higherLevelSlotDialog" useStoryboardIdentifierAsRestorationIdentifier="YES" id="GpO-Pl-HcB" customClass="HigherLevelSlotController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="GAW-fg-wte">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="7eY-Td-wXG" userLabel="Background View">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="7eY-Td-wXG" userLabel="Background View">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
                             </imageView>
                             <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C84-TB-2ig" userLabel="Content View">
@@ -873,6 +874,7 @@
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DLn-G1-ocq" userLabel="Cancel Button">
                                         <rect key="frame" x="248" y="96" width="75" height="35"/>
+                                        <color key="backgroundColor" systemColor="systemRedColor"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="Cancel">
                                             <color key="titleColor" name="DefaultFontColor"/>
@@ -880,6 +882,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o3o-4l-2pl" userLabel="Cast Button">
                                         <rect key="frame" x="331" y="96" width="75" height="35"/>
+                                        <color key="backgroundColor" systemColor="systemGreenColor"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="Cast">
                                             <color key="titleColor" name="DefaultFontColor"/>
@@ -3144,6 +3147,12 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGreenColor">
+            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -463,76 +463,76 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                                 <subviews>
                                     <view opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xTV-VH-ZcY" userLabel="Content View">
-                                        <rect key="frame" x="8" y="0.0" width="414" height="48"/>
+                                        <rect key="frame" x="8" y="0.0" width="414" height="241.33333333333334"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eMW-F5-hmt">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eMW-F5-hmt">
                                                 <rect key="frame" x="-62" y="21" width="363" height="85"/>
                                                 <fontDescription key="fontDescription" name="CloisterBlack-Light" family="Cloister Black" pointSize="45"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RLp-JA-JL3">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RLp-JA-JL3">
                                                 <rect key="frame" x="99" y="53" width="42" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pc4-lp-KCl">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pc4-lp-KCl">
                                                 <rect key="frame" x="5" y="5" width="350.33333333333331" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MBx-OV-kFQ">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MBx-OV-kFQ">
                                                 <rect key="frame" x="5" y="7" width="350.33333333333331" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LO2-Vv-zrI">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LO2-Vv-zrI">
                                                 <rect key="frame" x="5" y="9" width="350.33333333333331" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y43-NE-UnZ">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y43-NE-UnZ">
                                                 <rect key="frame" x="5" y="11" width="350.33333333333331" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUT-AL-0TC">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUT-AL-0TC">
                                                 <rect key="frame" x="5" y="13" width="350.33333333333331" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AnF-D5-EEE">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AnF-D5-EEE">
                                                 <rect key="frame" x="-384" y="64" width="1007" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="31Y-hW-A43">
-                                                <rect key="frame" x="5" y="13" width="404" height="0.0"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="31Y-hW-A43">
+                                                <rect key="frame" x="5" y="13" width="350.33333333333331" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Lk-KK-W3S">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Lk-KK-W3S">
                                                 <rect key="frame" x="-384" y="64" width="1007" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yfg-mz-Cj6">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yfg-mz-Cj6">
                                                 <rect key="frame" x="-384" y="64" width="1007" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BzG-dM-bz3">
-                                                <rect key="frame" x="5" y="19" width="404" height="0.0"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BzG-dM-bz3">
+                                                <rect key="frame" x="5" y="19" width="350.33333333333331" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
@@ -570,8 +570,8 @@
                                                 </constraints>
                                                 <state key="normal" image="book_empty.png"/>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qMf-rX-l1X" userLabel="Cast Button">
-                                                <rect key="frame" x="355.66666666666669" y="6" width="53" height="35"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qMf-rX-l1X" userLabel="Cast Button">
+                                                <rect key="frame" x="355.33333333333331" y="171.33333333333334" width="53.666666666666686" height="38"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                 <inset key="contentEdgeInsets" minX="8" minY="8" maxX="8" maxY="8"/>
@@ -583,7 +583,7 @@
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
                                                         <integer key="value" value="1"/>
                                                     </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.borderRadius">
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                                         <integer key="value" value="5"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
@@ -599,13 +599,15 @@
                                             <constraint firstItem="f6W-mZ-pXE" firstAttribute="trailing" secondItem="xTV-VH-ZcY" secondAttribute="trailing" constant="-5" id="4sw-XT-v3G"/>
                                             <constraint firstItem="z3p-02-z1G" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.13" id="6mi-9w-6p9"/>
                                             <constraint firstItem="MBx-OV-kFQ" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="71b-2R-D0o"/>
+                                            <constraint firstItem="qMf-rX-l1X" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.13" id="7h4-EI-z5J"/>
                                             <constraint firstItem="LO2-Vv-zrI" firstAttribute="top" secondItem="MBx-OV-kFQ" secondAttribute="bottom" constant="2" id="8xr-Zo-SgC"/>
                                             <constraint firstItem="qMf-rX-l1X" firstAttribute="top" relation="greaterThanOrEqual" secondItem="f6W-mZ-pXE" secondAttribute="bottom" constant="3" id="92H-bv-Tnh"/>
                                             <constraint firstItem="pc4-lp-KCl" firstAttribute="top" secondItem="RLp-JA-JL3" secondAttribute="bottom" constant="2" id="BSq-yV-P1q"/>
                                             <constraint firstItem="RLp-JA-JL3" firstAttribute="top" secondItem="eMW-F5-hmt" secondAttribute="bottom" constant="2" id="BbM-YP-TQ1"/>
-                                            <constraint firstItem="yfg-mz-Cj6" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="D9U-ca-A2c"/>
-                                            <constraint firstItem="AnF-D5-EEE" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="DDB-wx-n2b"/>
+                                            <constraint firstItem="yfg-mz-Cj6" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="D9U-ca-A2c"/>
+                                            <constraint firstItem="AnF-D5-EEE" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="DDB-wx-n2b"/>
                                             <constraint firstItem="z3p-02-z1G" firstAttribute="top" secondItem="xTV-VH-ZcY" secondAttribute="top" constant="1" id="Dgr-kl-XiZ"/>
+                                            <constraint firstItem="qMf-rX-l1X" firstAttribute="bottom" secondItem="0Wq-uU-OZd" secondAttribute="top" constant="-5" id="E0z-I2-duJ"/>
                                             <constraint firstItem="RLp-JA-JL3" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="J1H-ZK-DEV"/>
                                             <constraint firstItem="BzG-dM-bz3" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="Jbh-xP-8Fs"/>
                                             <constraint firstItem="omB-O3-Bun" firstAttribute="trailing" secondItem="xTV-VH-ZcY" secondAttribute="trailing" constant="-5" id="KxE-mk-khv"/>
@@ -619,19 +621,19 @@
                                             <constraint firstItem="BzG-dM-bz3" firstAttribute="top" secondItem="yfg-mz-Cj6" secondAttribute="bottom" constant="2" id="T0N-Qh-2vn"/>
                                             <constraint firstItem="AnF-D5-EEE" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="U39-6z-tlm"/>
                                             <constraint firstItem="AnF-D5-EEE" firstAttribute="top" secondItem="hUT-AL-0TC" secondAttribute="bottom" id="Uuh-X9-Mpb"/>
-                                            <constraint firstItem="BzG-dM-bz3" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="X8x-5M-YZP"/>
+                                            <constraint firstItem="BzG-dM-bz3" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="X8x-5M-YZP"/>
                                             <constraint firstItem="0Wq-uU-OZd" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="a8P-oo-PYZ"/>
                                             <constraint firstItem="7Lk-KK-W3S" firstAttribute="top" secondItem="31Y-hW-A43" secondAttribute="bottom" constant="2" id="aV6-xJ-nzf"/>
                                             <constraint firstItem="fny-iQ-Av2" firstAttribute="bottom" secondItem="xTV-VH-ZcY" secondAttribute="bottom" constant="-25" id="aru-dz-b2o"/>
                                             <constraint firstItem="yfg-mz-Cj6" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="bSt-tC-XnY"/>
                                             <constraint firstItem="f6W-mZ-pXE" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.13" id="czw-2a-qkd"/>
-                                            <constraint firstItem="7Lk-KK-W3S" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="dHb-v6-bje"/>
+                                            <constraint firstItem="7Lk-KK-W3S" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="dHb-v6-bje"/>
                                             <constraint firstItem="7Lk-KK-W3S" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="dJ1-0n-Bjg"/>
                                             <constraint firstItem="y43-NE-UnZ" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="dU9-Ux-a9b"/>
                                             <constraint firstItem="qMf-rX-l1X" firstAttribute="centerX" secondItem="f6W-mZ-pXE" secondAttribute="centerX" id="fdo-qZ-j2g"/>
                                             <constraint firstItem="31Y-hW-A43" firstAttribute="top" secondItem="AnF-D5-EEE" secondAttribute="bottom" id="frZ-29-dsB"/>
                                             <constraint firstItem="eMW-F5-hmt" firstAttribute="top" secondItem="xTV-VH-ZcY" secondAttribute="top" constant="1" id="gVE-Jr-UFL"/>
-                                            <constraint firstItem="31Y-hW-A43" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="hkg-yA-02R"/>
+                                            <constraint firstItem="31Y-hW-A43" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="hkg-yA-02R"/>
                                             <constraint firstItem="eMW-F5-hmt" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="iv9-YV-JUB"/>
                                             <constraint firstItem="0Wq-uU-OZd" firstAttribute="top" secondItem="BzG-dM-bz3" secondAttribute="bottom" constant="2" id="j65-b6-WWd"/>
                                             <constraint firstItem="fny-iQ-Av2" firstAttribute="top" secondItem="0Wq-uU-OZd" secondAttribute="bottom" constant="2" id="lil-Ia-17Z"/>

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -769,6 +769,92 @@
             </objects>
             <point key="canvasLocation" x="4540.579710144928" y="-193.52678571428569"/>
         </scene>
+        <!--Higher Level Slot Controller-->
+        <scene sceneID="Uyg-Ic-rFW">
+            <objects>
+                <viewController modalPresentationStyle="overCurrentContext" id="GpO-Pl-HcB" customClass="HigherLevelSlotController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="GAW-fg-wte">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="7eY-Td-wXG" userLabel="Background View">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="400"/>
+                            </imageView>
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C84-TB-2ig" userLabel="Content View">
+                                <rect key="frame" x="0.0" y="44" width="414" height="158"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select Slot Level" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8kD-zX-U6U" userLabel="Higher Level Title">
+                                        <rect key="frame" x="67" y="0.0" width="280" height="47"/>
+                                        <fontDescription key="fontDescription" name="CloisterBlack-Light" family="Cloister Black" pointSize="40"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Slot level:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p7L-NE-wKL" userLabel="Slot Level Label">
+                                        <rect key="frame" x="0.0" y="56" width="74" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DLn-G1-ocq" userLabel="Cancel Button">
+                                        <rect key="frame" x="248" y="96" width="75" height="35"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Cancel">
+                                            <color key="titleColor" name="DefaultFontColor"/>
+                                        </state>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o3o-4l-2pl" userLabel="Cast Button">
+                                        <rect key="frame" x="331" y="96" width="75" height="35"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Cast">
+                                            <color key="titleColor" name="DefaultFontColor"/>
+                                        </state>
+                                    </button>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="aor-Nx-U24">
+                                        <rect key="frame" x="132" y="55" width="97" height="34"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="o3o-4l-2pl" secondAttribute="trailing" constant="10" id="7PR-wh-BnQ"/>
+                                    <constraint firstItem="8kD-zX-U6U" firstAttribute="centerX" secondItem="C84-TB-2ig" secondAttribute="centerX" id="Ax7-Kg-VRL"/>
+                                    <constraint firstItem="aor-Nx-U24" firstAttribute="centerY" secondItem="p7L-NE-wKL" secondAttribute="centerY" id="EVE-9H-2Gp"/>
+                                    <constraint firstItem="DLn-G1-ocq" firstAttribute="top" secondItem="aor-Nx-U24" secondAttribute="bottom" constant="8" id="K7c-Ij-tj8"/>
+                                    <constraint firstItem="aor-Nx-U24" firstAttribute="leading" secondItem="p7L-NE-wKL" secondAttribute="trailing" constant="3" id="Lwt-B8-xeY"/>
+                                    <constraint firstItem="o3o-4l-2pl" firstAttribute="leading" secondItem="DLn-G1-ocq" secondAttribute="trailing" constant="15" id="fT7-Ky-mMg"/>
+                                    <constraint firstItem="o3o-4l-2pl" firstAttribute="centerY" secondItem="DLn-G1-ocq" secondAttribute="centerY" id="ilF-39-5v6"/>
+                                    <constraint firstItem="p7L-NE-wKL" firstAttribute="leading" secondItem="C84-TB-2ig" secondAttribute="leading" id="qVg-za-rRj"/>
+                                    <constraint firstItem="8kD-zX-U6U" firstAttribute="top" secondItem="C84-TB-2ig" secondAttribute="top" id="quA-da-ReZ"/>
+                                    <constraint firstItem="p7L-NE-wKL" firstAttribute="top" secondItem="8kD-zX-U6U" secondAttribute="bottom" constant="3" id="xw4-bW-bRi"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="PH6-9Z-iKn"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="PH6-9Z-iKn" firstAttribute="trailing" secondItem="7eY-Td-wXG" secondAttribute="trailing" id="2Vl-mq-Tqi"/>
+                            <constraint firstItem="7eY-Td-wXG" firstAttribute="top" secondItem="GAW-fg-wte" secondAttribute="top" id="CUe-JW-6SR"/>
+                            <constraint firstItem="7eY-Td-wXG" firstAttribute="leading" secondItem="PH6-9Z-iKn" secondAttribute="leading" id="DFq-6s-sFg"/>
+                            <constraint firstItem="C84-TB-2ig" firstAttribute="leading" secondItem="PH6-9Z-iKn" secondAttribute="leading" id="YJA-Ug-IYW"/>
+                            <constraint firstItem="PH6-9Z-iKn" firstAttribute="trailing" secondItem="C84-TB-2ig" secondAttribute="trailing" id="gm8-oU-b8L"/>
+                            <constraint firstAttribute="bottom" secondItem="7eY-Td-wXG" secondAttribute="bottom" id="jU9-tH-a7P"/>
+                            <constraint firstItem="C84-TB-2ig" firstAttribute="top" secondItem="PH6-9Z-iKn" secondAttribute="top" id="wfv-IL-M9y"/>
+                        </constraints>
+                    </view>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="414" height="400"/>
+                    <connections>
+                        <outlet property="cancelButton" destination="DLn-G1-ocq" id="65A-MN-5od"/>
+                        <outlet property="castButton" destination="o3o-4l-2pl" id="qqv-sT-QRv"/>
+                        <outlet property="slotLevelChooser" destination="aor-Nx-U24" id="RVJ-L1-UEN"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BoP-QS-Ys0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5500" y="-747"/>
+        </scene>
         <!--Import Character Controller-->
         <scene sceneID="zDk-3k-MFU">
             <objects>

--- a/Spellbook/ConfirmNextAvailableCastController.swift
+++ b/Spellbook/ConfirmNextAvailableCastController.swift
@@ -1,0 +1,54 @@
+//
+//  ConfirmNextAvailableCastController.swift
+//  Spellbook
+//
+//  Created by Mac Pro on 10/23/23.
+//  Copyright © 2023 Jonathan Carifio. All rights reserved.
+//
+
+import UIKit
+
+class ConfirmNextAvailableCastController: UIViewController {
+    
+    @IBOutlet weak var availableCastMessage: UILabel!
+    @IBOutlet weak var yesButton: UIButton!
+    @IBOutlet weak var noButton: UIButton!
+    
+    var spell: Spell?
+    var level: Int = 0
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // We should never be here without an assigned profile
+        let name = store.state.profile?.name ?? ""
+        let baseLevel = spell?.level ?? 0
+        
+        availableCastMessage.text = "\(name) has no slots of level \(baseLevel) remaining. Would you like to use a slot of level \(level)?"
+        
+        noButton.addTarget(self, action: #selector(noButtonPressed), for: UIControl.Event.touchUpInside)
+        yesButton.addTarget(self, action: #selector(yesButtonPressed), for: UIControl.Event.touchUpInside)
+
+        // Do any additional setup after loading the view.
+    }
+    
+    @objc func noButtonPressed() {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    @objc func yesButtonPressed() {
+        self.dismiss(animated: true, completion: { () -> Void in
+            
+            if self.level == 0 {
+                return
+            }
+            if let spell = self.spell {
+                store.dispatch(CastSpellAction(level: self.level))
+                store.dispatch(ToastAction(message: "\(spell.name) was cast at level \(self.level)"))
+            }
+        })
+    }
+    
+}
+
+

--- a/Spellbook/ConfirmNextAvailableCastController.swift
+++ b/Spellbook/ConfirmNextAvailableCastController.swift
@@ -16,6 +16,9 @@ class ConfirmNextAvailableCastController: UIViewController {
     
     var spell: Spell?
     var level: Int = 0
+    
+    // TODO: What's a better way to do this?
+    var toastController: UIViewController? = nil
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,7 +47,10 @@ class ConfirmNextAvailableCastController: UIViewController {
             }
             if let spell = self.spell {
                 store.dispatch(CastSpellAction(level: self.level))
-                store.dispatch(ToastAction(message: "\(spell.name) was cast at level \(self.level)"))
+                
+                let message = "\(spell.name) was cast at level \(self.level)"
+                let controller = self.toastController ?? (self.parent ?? self)
+                Toast.makeToast(message, controller: controller)
             }
         })
     }

--- a/Spellbook/DeletionPromptController.swift
+++ b/Spellbook/DeletionPromptController.swift
@@ -93,16 +93,5 @@ class DeletionPromptController: UIViewController {
             self.main!.openCharacterCreationDialog(mustComplete: creationNecessary)
         })
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }

--- a/Spellbook/DeletionPromptController.swift
+++ b/Spellbook/DeletionPromptController.swift
@@ -24,14 +24,12 @@ class DeletionPromptController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // Set the text
+
         deleteMessage.text = "Are you sure you want to delete \(name ?? "")?"
-        
+
         // Set the layout
         //setLayout()
-        
-        // Set the button functions
+
         noButton.addTarget(self, action: #selector(noButtonPressed), for: UIControl.Event.touchUpInside)
         yesButton.addTarget(self, action: #selector(yesButtonPressed), for: UIControl.Event.touchUpInside)
 

--- a/Spellbook/HigherLevelSlotController.swift
+++ b/Spellbook/HigherLevelSlotController.swift
@@ -11,7 +11,7 @@ import UIKit
 import ReSwift
 
 class HigherLevelSlotController: UIViewController {
-
+    
     @IBOutlet weak var slotLevelChooser: UITextField!
     @IBOutlet weak var cancelButton: UIButton!
     @IBOutlet weak var castButton: UIButton!
@@ -22,7 +22,7 @@ class HigherLevelSlotController: UIViewController {
         super.viewDidLoad()
         
         cancelButton.addTarget(self, action: #selector(cancelButtonPressed), for: UIControl.Event.touchUpInside)
-        castButton.addTarget(self, action: #selector(castButtonPressed), for: UIControl.Event.touchUpInside)
+        //castButton.addTarget(self, action: #selector(castButtonPressed), for: UIControl.Event.touchUpInside)
         
         guard let spell = self.spell else { return }
         guard let profile = store.state.profile else { return }
@@ -52,17 +52,17 @@ class HigherLevelSlotController: UIViewController {
         self.dismiss(animated: true, completion: nil)
     }
     
-    @objc func castButtonPressed() {
-        guard let spell = self.spell else { return }
-        if let text = slotLevelChooser.text {
-            if let level = valueFrom(ordinal: text) {
-                store.dispatch(CastSpellAction(level: level))
-                let message = "\(spell.name) was cast at level \(level)"
-                Toast.makeToast(message, controller: self.parent ?? self)
-            }
-        }
-        
-        self.dismiss(animated: true, completion: nil)
-    }
+//    @objc func castButtonPressed() {
+//        guard let spell = self.spell else { return }
+//        if let text = slotLevelChooser.text {
+//            if let level = valueFrom(ordinal: text) {
+//                store.dispatch(CastSpellAction(level: level))
+//                let message = "\(spell.name) was cast at level \(level)"
+//                Toast.makeToast(message, controller: self.parent ?? self)
+//            }
+//        }
+//
+//        self.dismiss(animated: true, completion: nil)
+//    }
 
 }

--- a/Spellbook/HigherLevelSlotController.swift
+++ b/Spellbook/HigherLevelSlotController.swift
@@ -35,20 +35,21 @@ class HigherLevelSlotController: UIViewController {
         let maxLevel = status.maxLevelWithSlots()
         let range = baseLevel...maxLevel
         
-        // TODO: It's kind of gross to need to use this dummy type
-        // It feels like a refactor of the delegate is necessary
         let initialLevel = status.minLevelWithCondition(condition: { level in
             return status.hasAvailableSlots(level: level) && level >= baseLevel
         })
+
+        // TODO: It's kind of gross to need to use this dummy type
+        // It feels like a refactor of the delegate is necessary
         self.textDelegate = TextFieldChooserDelegate<GenericSpellbookAction, Int>(
             items: Array(range),
             title: "Select Slot Level",
-            itemProvider: {
-                () in return initialLevel
-            },
+            itemProvider: { () in return initialLevel },
             nameGetter: ordinal,
             textSetter: ordinal,
-            nameConstructor: { valueFrom(ordinal: $0) ?? 0 })
+            nameConstructor: { valueFrom(ordinal: $0) ?? 0 },
+            itemFilter: { level in return status.hasAvailableSlots(level: level) }
+        )
 
         slotLevelChooser.text = ordinal(number: initialLevel)
         slotLevelChooser.delegate = self.textDelegate!

--- a/Spellbook/HigherLevelSlotController.swift
+++ b/Spellbook/HigherLevelSlotController.swift
@@ -17,6 +17,7 @@ class HigherLevelSlotController: UIViewController {
     @IBOutlet weak var castButton: UIButton!
     
     var spell: Spell?
+    var textDelegate: TextFieldChooserDelegate<GenericSpellbookAction, Int>?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -33,19 +34,21 @@ class HigherLevelSlotController: UIViewController {
         
         // TODO: It's kind of gross to need to use this dummy type
         // It feels like a refactor of the delegate is necessary
-        let textDelegate = TextFieldChooserDelegate<GenericSpellbookAction, Int>(
+        let initialLevel = status.minLevelWithCondition(condition: { level in
+            return status.hasAvailableSlots(level: level) && level >= baseLevel
+        })
+        self.textDelegate = TextFieldChooserDelegate<GenericSpellbookAction, Int>(
             items: Array(range),
             title: "Select Slot Level",
             itemProvider: {
-                () in return status.minLevelWithCondition(condition: { level in
-                    return status.hasAvailableSlots(level: level) && level >= baseLevel
-                })
+                () in return initialLevel
             },
             nameGetter: ordinal,
             textSetter: ordinal,
             nameConstructor: { valueFrom(ordinal: $0) ?? 0 })
 
-        slotLevelChooser.delegate = textDelegate
+        slotLevelChooser.text = ordinal(number: initialLevel)
+        slotLevelChooser.delegate = self.textDelegate!
     }
     
     @objc func cancelButtonPressed() {

--- a/Spellbook/HigherLevelSlotController.swift
+++ b/Spellbook/HigherLevelSlotController.swift
@@ -18,12 +18,15 @@ class HigherLevelSlotController: UIViewController {
     
     var spell: Spell?
     var textDelegate: TextFieldChooserDelegate<GenericSpellbookAction, Int>?
+    
+    // TODO: What's a better way to do this?
+    var toastController: UIViewController? = nil
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
         cancelButton.addTarget(self, action: #selector(cancelButtonPressed), for: UIControl.Event.touchUpInside)
-        //castButton.addTarget(self, action: #selector(castButtonPressed), for: UIControl.Event.touchUpInside)
+        castButton.addTarget(self, action: #selector(castButtonPressed), for: UIControl.Event.touchUpInside)
         
         guard let spell = self.spell else { return }
         guard let profile = store.state.profile else { return }
@@ -61,7 +64,8 @@ class HigherLevelSlotController: UIViewController {
             if let level = valueFrom(ordinal: text) {
                 store.dispatch(CastSpellAction(level: level))
                 let message = "\(spell.name) was cast at level \(level)"
-                Toast.makeToast(message, controller: self.parent ?? self)
+                let controller = self.toastController ?? (self.parent ?? self)
+                Toast.makeToast(message, controller: controller)
             }
         }
 

--- a/Spellbook/HigherLevelSlotController.swift
+++ b/Spellbook/HigherLevelSlotController.swift
@@ -33,19 +33,19 @@ class HigherLevelSlotController: UIViewController {
         
         // TODO: It's kind of gross to need to use this dummy type
         // It feels like a refactor of the delegate is necessary
-        let textDelegate = TextFieldChooserDelegate<GenericSpellbookAction, Int>(
-            items: Array(range),
-            title: "Select Slot Level",
-            itemProvider: {
-                return status.minLevelWithCondition(condition: { level in
-                    return status.hasAvailableSlots(level: level) && level >= baseLevel
-                })
-            },
-            nameGetter: ordinal,
-            textSetter: ordinal,
-            nameConstructor: { valueFrom(ordinal: $0) ?? 0 })
-        
-        slotLevelChooser.delegate = textDelegate
+//        let textDelegate = TextFieldChooserDelegate<GenericSpellbookAction, Int>(
+//            items: Array(range),
+//            title: "Select Slot Level",
+//            itemProvider: {
+//                () in return status.minLevelWithCondition(condition: { level in
+//                    return status.hasAvailableSlots(level: level) && level >= baseLevel
+//                })
+//            },
+//            nameGetter: ordinal,
+//            textSetter: ordinal,
+//            nameConstructor: { valueFrom(ordinal: $0) ?? 0 })
+//
+//        slotLevelChooser.delegate = textDelegate
     }
     
     @objc func cancelButtonPressed() {
@@ -57,7 +57,8 @@ class HigherLevelSlotController: UIViewController {
         if let text = slotLevelChooser.text {
             if let level = valueFrom(ordinal: text) {
                 store.dispatch(CastSpellAction(level: level))
-                store.dispatch(ToastAction(message: "\(spell.name) was cast at level \(level)"))
+                let message = "\(spell.name) was cast at level \(level)"
+                Toast.makeToast(message, controller: self.parent ?? self)
             }
         }
         

--- a/Spellbook/HigherLevelSlotController.swift
+++ b/Spellbook/HigherLevelSlotController.swift
@@ -33,36 +33,36 @@ class HigherLevelSlotController: UIViewController {
         
         // TODO: It's kind of gross to need to use this dummy type
         // It feels like a refactor of the delegate is necessary
-//        let textDelegate = TextFieldChooserDelegate<GenericSpellbookAction, Int>(
-//            items: Array(range),
-//            title: "Select Slot Level",
-//            itemProvider: {
-//                () in return status.minLevelWithCondition(condition: { level in
-//                    return status.hasAvailableSlots(level: level) && level >= baseLevel
-//                })
-//            },
-//            nameGetter: ordinal,
-//            textSetter: ordinal,
-//            nameConstructor: { valueFrom(ordinal: $0) ?? 0 })
-//
-//        slotLevelChooser.delegate = textDelegate
+        let textDelegate = TextFieldChooserDelegate<GenericSpellbookAction, Int>(
+            items: Array(range),
+            title: "Select Slot Level",
+            itemProvider: {
+                () in return status.minLevelWithCondition(condition: { level in
+                    return status.hasAvailableSlots(level: level) && level >= baseLevel
+                })
+            },
+            nameGetter: ordinal,
+            textSetter: ordinal,
+            nameConstructor: { valueFrom(ordinal: $0) ?? 0 })
+
+        slotLevelChooser.delegate = textDelegate
     }
     
     @objc func cancelButtonPressed() {
         self.dismiss(animated: true, completion: nil)
     }
     
-//    @objc func castButtonPressed() {
-//        guard let spell = self.spell else { return }
-//        if let text = slotLevelChooser.text {
-//            if let level = valueFrom(ordinal: text) {
-//                store.dispatch(CastSpellAction(level: level))
-//                let message = "\(spell.name) was cast at level \(level)"
-//                Toast.makeToast(message, controller: self.parent ?? self)
-//            }
-//        }
-//
-//        self.dismiss(animated: true, completion: nil)
-//    }
+    @objc func castButtonPressed() {
+        guard let spell = self.spell else { return }
+        if let text = slotLevelChooser.text {
+            if let level = valueFrom(ordinal: text) {
+                store.dispatch(CastSpellAction(level: level))
+                let message = "\(spell.name) was cast at level \(level)"
+                Toast.makeToast(message, controller: self.parent ?? self)
+            }
+        }
+
+        self.dismiss(animated: true, completion: nil)
+    }
 
 }

--- a/Spellbook/HigherLevelSlotController.swift
+++ b/Spellbook/HigherLevelSlotController.swift
@@ -37,7 +37,7 @@ class HigherLevelSlotController: UIViewController {
             items: Array(range),
             title: "Select Slot Level",
             itemProvider: {
-                status.minLevelWithCondition(condition: { level in
+                return status.minLevelWithCondition(condition: { level in
                     return status.hasAvailableSlots(level: level) && level >= baseLevel
                 })
             },

--- a/Spellbook/HigherLevelSlotController.swift
+++ b/Spellbook/HigherLevelSlotController.swift
@@ -1,0 +1,67 @@
+//
+//  HigherLevelSlotController.swift
+//  Spellbook
+//
+//  Created by Mac Pro on 10/14/23.
+//  Copyright © 2023 Jonathan Carifio. All rights reserved.
+//
+
+import UIKit
+
+import ReSwift
+
+class HigherLevelSlotController: UIViewController {
+
+    @IBOutlet weak var slotLevelChooser: UITextField!
+    @IBOutlet weak var cancelButton: UIButton!
+    @IBOutlet weak var castButton: UIButton!
+    
+    var spell: Spell?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        cancelButton.addTarget(self, action: #selector(cancelButtonPressed), for: UIControl.Event.touchUpInside)
+        castButton.addTarget(self, action: #selector(castButtonPressed), for: UIControl.Event.touchUpInside)
+        
+        guard let spell = self.spell else { return }
+        guard let profile = store.state.profile else { return }
+        let status = profile.spellSlotStatus
+        let baseLevel = spell.level
+        let maxLevel = status.maxLevelWithSlots()
+        let range = baseLevel...maxLevel
+        
+        // TODO: It's kind of gross to need to use this dummy type
+        // It feels like a refactor of the delegate is necessary
+        let textDelegate = TextFieldChooserDelegate<GenericSpellbookAction, Int>(
+            items: Array(range),
+            title: "Select Slot Level",
+            itemProvider: {
+                status.minLevelWithCondition(condition: { level in
+                    return status.hasAvailableSlots(level: level) && level >= baseLevel
+                })
+            },
+            nameGetter: ordinal,
+            textSetter: ordinal,
+            nameConstructor: { valueFrom(ordinal: $0) ?? 0 })
+        
+        slotLevelChooser.delegate = textDelegate
+    }
+    
+    @objc func cancelButtonPressed() {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    @objc func castButtonPressed() {
+        guard let spell = self.spell else { return }
+        if let text = slotLevelChooser.text {
+            if let level = valueFrom(ordinal: text) {
+                store.dispatch(CastSpellAction(level: level))
+                store.dispatch(ToastAction(message: "\(spell.name) was cast at level \(level)"))
+            }
+        }
+        
+        self.dismiss(animated: true, completion: nil)
+    }
+
+}

--- a/Spellbook/SpellFilter.swift
+++ b/Spellbook/SpellFilter.swift
@@ -102,6 +102,9 @@ func filterSpell(spell: Spell, sortFilterStatus: SortFilterStatus, spellFilterSt
     toHide = toHide || (sortFilterStatus.preparedSelected() && !spellFilterStatus.isPrepared(spell))
     toHide = toHide || !sortFilterStatus.getRitualFilter(spell.ritual)
     toHide = toHide || !sortFilterStatus.getConcentrationFilter(spell.concentration)
+    toHide = toHide || !sortFilterStatus.getVerbalFilter(spell.verbal)
+    toHide = toHide || !sortFilterStatus.getSomaticFilter(spell.somatic)
+    toHide = toHide || !sortFilterStatus.getMaterialFilter(spell.material)
     toHide = toHide || (isText && !spellName.contains(text))
     return !toHide
 }

--- a/Spellbook/SpellSlotStatus.swift
+++ b/Spellbook/SpellSlotStatus.swift
@@ -68,7 +68,7 @@ class SpellSlotStatus {
         usedSlots[level - 1] = max(usedSlots[level - 1] - 1, 0)
     }
 
-    func levelWithCondition(condition: Predicate<Int>, range: ClosedRange<Int>) -> Int {
+    func levelWithCondition<SeqInt: Sequence>(condition: Predicate<Int>, range: SeqInt) -> Int where SeqInt.Iterator.Element == Int {
         for level in range {
             if condition(level) {
                 return level
@@ -78,11 +78,11 @@ class SpellSlotStatus {
     }
 
     func minLevelWithCondition(condition: Predicate<Int>) -> Int {
-        return levelWithCondition(condition: condition, range: Spellbook.MIN_SPELL_LEVEL...Spellbook.MAX_SPELL_LEVEL)
+        return levelWithCondition(condition: condition, range: 1...Spellbook.MAX_SPELL_LEVEL)
     }
 
     func maxLevelWithCondition(condition: Predicate<Int>) -> Int {
-        return levelWithCondition(condition: condition, range: Spellbook.MAX_SPELL_LEVEL...Spellbook.MIN_SPELL_LEVEL)
+        return levelWithCondition(condition: condition, range: (1...Spellbook.MAX_SPELL_LEVEL).reversed())
     }
 
     func minLevelWithSlots() -> Int {

--- a/Spellbook/SpellSlotStatus.swift
+++ b/Spellbook/SpellSlotStatus.swift
@@ -15,7 +15,7 @@ class SpellSlotStatus {
     
     private static let totalSlotsKey = "totalSlots"
     private static let usedSlotsKey = "usedSlotsKey"
-    
+
     init(totalSlots: [Int], usedSlots: [Int]) {
         self.totalSlots = totalSlots
         self.usedSlots = usedSlots
@@ -37,6 +37,9 @@ class SpellSlotStatus {
     func getUsedSlots(level: Int) -> Int { return usedSlots[level - 1] }
     func getAvailableSlots(level: Int) -> Int { return totalSlots[level - 1] - usedSlots[level - 1] }
     
+    func hasSlots(level: Int) -> Bool { return getTotalSlots(level: level) > 0 }
+    func hasAvailableSlots(level: Int) -> Bool { return getAvailableSlots(level: level) > 0 }
+
     func setTotalSlots(level: Int, slots: Int) {
         totalSlots[level - 1] = slots
         if (slots < usedSlots[level - 1]) {
@@ -48,37 +51,65 @@ class SpellSlotStatus {
         let used = totalSlots[level - 1] - slots
         usedSlots[level - 1] = max(0, used)
     }
-    
+
     func setUsedSlots(level: Int, slots: Int) {
         usedSlots[level - 1] = min(slots, totalSlots[level - 1])
     }
-    
+
     func regainAllSlots() {
         usedSlots = usedSlots.map { _ in 0 }
     }
-    
+
     func useSlot(level: Int) {
         usedSlots[level - 1] = min(usedSlots[level - 1] + 1, totalSlots[level - 1])
     }
-    
+
     func gainSlot(level: Int) {
         usedSlots[level - 1] = max(usedSlots[level - 1] - 1, 0)
     }
-    
-    func maxLevelWithSlots() -> Int {
-        for level in Spellbook.MAX_SPELL_LEVEL...1 {
-            if (self.getTotalSlots(level: level) > 0) {
+
+    func levelWithCondition(condition: Predicate<Int>, range: ClosedRange<Int>) -> Int {
+        for level in range {
+            if condition(level) {
                 return level
             }
         }
         return 0
     }
-    
+
+    func minLevelWithCondition(condition: Predicate<Int>) -> Int {
+        return levelWithCondition(condition: condition, range: Spellbook.MIN_SPELL_LEVEL...Spellbook.MAX_SPELL_LEVEL)
+    }
+
+    func maxLevelWithCondition(condition: Predicate<Int>) -> Int {
+        return levelWithCondition(condition: condition, range: Spellbook.MAX_SPELL_LEVEL...Spellbook.MIN_SPELL_LEVEL)
+    }
+
+    func minLevelWithSlots() -> Int {
+        return minLevelWithCondition(condition: self.hasSlots)
+    }
+
+    func maxLevelWithSlots() -> Int {
+        return maxLevelWithCondition(condition: self.hasSlots)
+    }
+
+    func minLevelWithAvailableSlots() -> Int {
+        return minLevelWithCondition(condition: self.hasAvailableSlots)
+    }
+
+    func maxLevelWithAvailableSlots() -> Int {
+        return maxLevelWithCondition(condition: self.hasAvailableSlots)
+    }
+
+    func nextAvailableSlotLevel(baseLevel: Int) -> Int {
+        return levelWithCondition(condition: self.hasAvailableSlots, range: baseLevel...Spellbook.MAX_SPELL_LEVEL)
+    }
+
     func toSION() -> SION {
         var sion: SION = [:]
         sion[SpellSlotStatus.totalSlotsKey].array = totalSlots.map { SION($0) }
         sion[SpellSlotStatus.usedSlotsKey].array = usedSlots.map { SION($0) }
         return sion
     }
-    
+
 }

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -146,6 +146,9 @@ class SpellWindowController: UIViewController {
         
         var needsLayoutUpdate = false
         
+        // Don't show the cast button for cantrips
+        castButton.isHidden = spell.level == 0
+        
         // Set the text on the name label
         spellNameLabel.text = spell.name
         
@@ -228,7 +231,39 @@ class SpellWindowController: UIViewController {
         guard let profile = store.state.profile else { return }
         let level = spell.level
         let status = profile.spellSlotStatus
+        var message: String?
+        if level > status.maxLevelWithSlots() {
+            message = "\(profile.name) has no slots of level \(level) or above!"
+        } else if level > status.maxLevelWithAvailableSlots() {
+            message = "\(profile.name) has no available slots of level \(level) or above!"
+        } else if !spell.higherLevel.isEmpty {
+            let controller = storyboard?.instantiateViewController(withIdentifier: "higherLevelSlotDialog") as! HigherLevelSlotController
+            controller.spell = spell
+            let popupHeight = 0.33 * SizeUtils.screenHeight
+            let popupWidth = 0.75 * SizeUtils.screenWidth
+            let height = min(popupHeight, CGFloat(320))
+            let width = min(popupWidth, CGFloat(370))
+            let popupVC = PopupViewController(contentController: controller, popupWidth: width, popupHeight: height)
+            self.present(popupVC, animated: true, completion: nil)
+        } else if status.getAvailableSlots(level: level) == 0 {
+            let levelToUse = status.nextAvailableSlotLevel(baseLevel: level)
+            let controller = storyboard?.instantiateViewController(withIdentifier: "confirmNextAvailableCast") as! ConfirmNextAvailableCastController
+            controller.spell = spell
+            controller.level = levelToUse
+            let popupHeight = 0.33 * SizeUtils.screenHeight
+            let popupWidth = 0.75 * SizeUtils.screenWidth
+            let height = min(popupHeight, CGFloat(250))
+            let width = min(popupWidth, CGFloat(370))
+            let popupVC = PopupViewController(contentController: controller, popupWidth: width, popupHeight: height)
+            self.present(popupVC, animated: true, completion: nil)
+        } else {
+            store.dispatch(CastSpellAction(level: level))
+            message = "\(spell.name) was cast"
+        }
         
+        if let toast = message {
+            self.view.makeToast(toast, duration: Constants.toastDuration)
+        }
     }
 
 }

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -232,27 +232,29 @@ class SpellWindowController: UIViewController {
         let level = spell.level
         let status = profile.spellSlotStatus
         var message: String?
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
         if level > status.maxLevelWithSlots() {
             message = "\(profile.name) has no slots of level \(level) or above!"
         } else if level > status.maxLevelWithAvailableSlots() {
             message = "\(profile.name) has no available slots of level \(level) or above!"
         } else if !spell.higherLevel.isEmpty {
-            let controller = storyboard?.instantiateViewController(withIdentifier: "higherLevelSlotDialog") as! HigherLevelSlotController
+            let controller = storyboard.instantiateViewController(withIdentifier: "higherLevelSlotDialog") as! HigherLevelSlotController
             controller.spell = spell
             let popupHeight = 0.33 * SizeUtils.screenHeight
             let popupWidth = 0.75 * SizeUtils.screenWidth
-            let height = min(popupHeight, CGFloat(320))
+            let height = min(popupHeight, CGFloat(170))
             let width = min(popupWidth, CGFloat(370))
             let popupVC = PopupViewController(contentController: controller, popupWidth: width, popupHeight: height)
             self.present(popupVC, animated: true, completion: nil)
         } else if status.getAvailableSlots(level: level) == 0 {
             let levelToUse = status.nextAvailableSlotLevel(baseLevel: level)
-            let controller = storyboard?.instantiateViewController(withIdentifier: "confirmNextAvailableCast") as! ConfirmNextAvailableCastController
+            let controller = storyboard.instantiateViewController(withIdentifier: "confirmNextAvailableCast") as! ConfirmNextAvailableCastController
             controller.spell = spell
             controller.level = levelToUse
+            controller.toastController = self
             let popupHeight = 0.33 * SizeUtils.screenHeight
             let popupWidth = 0.75 * SizeUtils.screenWidth
-            let height = min(popupHeight, CGFloat(250))
+            let height = min(popupHeight, CGFloat(150))
             let width = min(popupWidth, CGFloat(370))
             let popupVC = PopupViewController(contentController: controller, popupWidth: width, popupHeight: height)
             self.present(popupVC, animated: true, completion: nil)

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -60,6 +60,9 @@ class SpellWindowController: UIViewController {
     @IBOutlet weak var preparedButton: ToggleButton!
     @IBOutlet weak var knownButton: ToggleButton!
     
+    // The cast button
+    @IBOutlet weak var castButton: UIButton!
+
     @IBOutlet weak var backgroundView: UIImageView!
     
     // Spacing constraints for the spacing between the components/materials/royalties/duration labels

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -242,7 +242,7 @@ class SpellWindowController: UIViewController {
             controller.spell = spell
             let popupHeight = 0.33 * SizeUtils.screenHeight
             let popupWidth = 0.75 * SizeUtils.screenWidth
-            let height = min(popupHeight, CGFloat(170))
+            let height = min(popupHeight, CGFloat(135))
             let width = min(popupWidth, CGFloat(370))
             let popupVC = PopupViewController(contentController: controller, popupWidth: width, popupHeight: height)
             self.present(popupVC, animated: true, completion: nil)
@@ -254,7 +254,7 @@ class SpellWindowController: UIViewController {
             controller.toastController = self
             let popupHeight = 0.33 * SizeUtils.screenHeight
             let popupWidth = 0.75 * SizeUtils.screenWidth
-            let height = min(popupHeight, CGFloat(150))
+            let height = min(popupHeight, CGFloat(155))
             let width = min(popupWidth, CGFloat(370))
             let popupVC = PopupViewController(contentController: controller, popupWidth: width, popupHeight: height)
             self.present(popupVC, animated: true, completion: nil)

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -240,6 +240,7 @@ class SpellWindowController: UIViewController {
         } else if !spell.higherLevel.isEmpty {
             let controller = storyboard.instantiateViewController(withIdentifier: "higherLevelSlotDialog") as! HigherLevelSlotController
             controller.spell = spell
+            controller.toastController = self
             let popupHeight = 0.33 * SizeUtils.screenHeight
             let popupWidth = 0.75 * SizeUtils.screenWidth
             let height = min(popupHeight, CGFloat(135))

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -107,6 +107,8 @@ class SpellWindowController: UIViewController {
             store.dispatch(TogglePropertyAction(spell: self.spell, property: .Known))
         })
         
+        castButton.addTarget(self, action: #selector(self.onCastClicked), for: UIControl.Event.touchUpInside)
+        
         // Set the content view to fill the screen
         contentView.frame = UIScreen.main.bounds
         
@@ -220,6 +222,13 @@ class SpellWindowController: UIViewController {
     
     func locationText(_ s: Spell) -> String {
          return s.locations.map { $0.key.code.uppercased() + " " + String($0.value) }.joined(separator: ", ")
+    }
+    
+    @objc func onCastClicked() {
+        guard let profile = store.state.profile else { return }
+        let level = spell.level
+        let status = profile.spellSlotStatus
+        
     }
 
 }

--- a/Spellbook/SpellbookActions.swift
+++ b/Spellbook/SpellbookActions.swift
@@ -229,3 +229,7 @@ struct RegainAllSlotsAction: Action {}
 
 // TODO: Is there a better way to do this?
 struct MarkAllSpellsCleanAction: Action {}
+
+struct CastSpellAction: Action {
+    let level: Int
+}

--- a/Spellbook/SpellbookActions.swift
+++ b/Spellbook/SpellbookActions.swift
@@ -8,6 +8,8 @@
 
 import ReSwift
 
+struct GenericSpellbookAction: Action {}
+
 struct SortFieldAction: Action {
     let sortField: SortField
     let level: Int
@@ -232,4 +234,8 @@ struct MarkAllSpellsCleanAction: Action {}
 
 struct CastSpellAction: Action {
     let level: Int
+}
+
+struct ToastAction: Action {
+    let message: String
 }

--- a/Spellbook/SpellbookMiddleware.swift
+++ b/Spellbook/SpellbookMiddleware.swift
@@ -161,6 +161,7 @@ let makeToastMiddleware: AppMiddleware = {
                 next(action)
                 return
             }
+            
             Toast.makeToast(toastAction.message)
         }
     }

--- a/Spellbook/SpellbookMiddleware.swift
+++ b/Spellbook/SpellbookMiddleware.swift
@@ -152,3 +152,16 @@ let deleteProfileByNameMiddleware: AppMiddleware = {
         }
     }
 }
+
+let makeToastMiddleware: AppMiddleware = {
+    dispatch, getState in
+    return { next in
+        return { action in
+            guard let toastAction = action as? ToastAction else {
+                next(action)
+                return
+            }
+            Toast.makeToast(toastAction.message)
+        }
+    }
+}

--- a/Spellbook/SpellbookReducers.swift
+++ b/Spellbook/SpellbookReducers.swift
@@ -351,3 +351,10 @@ func saveSettingsReducer(action: SaveSettingsAction, state: inout SpellbookAppSt
     SerializationUtils.saveSettings(state.settings)
     return state
 }
+
+func castSpellReducer(action: CastSpellAction, state: SpellbookAppState) -> SpellbookAppState {
+    guard let profile = state.profile else { return state }
+    let status = profile.spellSlotStatus
+    status.useSlot(level: action.level)
+    return state
+}

--- a/Spellbook/TextFieldChooserDelegate.swift
+++ b/Spellbook/TextFieldChooserDelegate.swift
@@ -23,13 +23,13 @@ class TextFieldChooserDelegate<A: Action, T:Equatable>: NSObject, UITextFieldDel
     
     let itemProvider: ItemProvider
     let items: [T]
-    let actionCreator: ActionCreator
+    let actionCreator: ActionCreator?
     let nameGetter: StringGetter
     let textSetter: StringGetter
     let nameConstructor: StringConstructor
     let itemFilter: ItemFilter?
     
-    init(items: [T], title: String, itemProvider: @escaping ItemProvider, actionCreator: @escaping ActionCreator, nameGetter: @escaping StringGetter, textSetter: @escaping StringGetter, nameConstructor: @escaping StringConstructor, itemFilter: ItemFilter? = nil) {
+    init(items: [T], title: String, itemProvider: @escaping ItemProvider, actionCreator: ActionCreator? = nil, nameGetter: @escaping StringGetter, textSetter: @escaping StringGetter, nameConstructor: @escaping StringConstructor, itemFilter: ItemFilter? = nil) {
         self.items = items
         self.itemProvider = itemProvider
         self.actionCreator = actionCreator
@@ -67,7 +67,9 @@ class TextFieldChooserDelegate<A: Action, T:Equatable>: NSObject, UITextFieldDel
                      picker, index, value in
                      let valueStr = value as! String
                      let item = self.nameConstructor(valueStr)
-                     store.dispatch(self.actionCreator(item))
+                     if let creator = self.actionCreator {
+                         store.dispatch(creator(item))
+                     }
                      sender.text = self.textSetter(item)
                      sender.endEditing(true)
                      return
@@ -82,7 +84,7 @@ class TextFieldChooserDelegate<A: Action, T:Equatable>: NSObject, UITextFieldDel
 
 class TextFieldIterableChooserDelegate<A:Action, T:CaseIterable & Equatable>: TextFieldChooserDelegate<A,T> {
     
-    init(title: String, itemProvider: @escaping ItemProvider, actionCreator: @escaping ActionCreator, nameGetter: @escaping StringGetter, textSetter: @escaping StringGetter, nameConstructor: @escaping StringConstructor, itemFilter: ItemFilter? = nil) {
+    init(title: String, itemProvider: @escaping ItemProvider, actionCreator: ActionCreator? = nil, nameGetter: @escaping StringGetter, textSetter: @escaping StringGetter, nameConstructor: @escaping StringConstructor, itemFilter: ItemFilter? = nil) {
         let items = T.allCases.map({ $0 })
         super.init(items: items,
                    title: title,
@@ -103,7 +105,7 @@ class TextFieldIterableChooserDelegate<A:Action, T:CaseIterable & Equatable>: Te
 
 class NameConstructibleChooserDelegate<A:Action, N:NameConstructible>: TextFieldIterableChooserDelegate<A,N> {
     
-    init(itemProvider: @escaping ItemProvider, actionCreator: @escaping ActionCreator, title: String) {
+    init(itemProvider: @escaping ItemProvider, actionCreator: ActionCreator? = nil, title: String) {
         super.init(title: title,
                    itemProvider: itemProvider,
                    actionCreator: actionCreator,
@@ -114,7 +116,7 @@ class NameConstructibleChooserDelegate<A:Action, N:NameConstructible>: TextField
 }
 
 class UnitChooserDelegate<A:Action, U:Unit> : TextFieldIterableChooserDelegate<A,U> {
-    init(itemProvider: @escaping ItemProvider, actionCreator: @escaping ActionCreator, title: String) {
+    init(itemProvider: @escaping ItemProvider, actionCreator: ActionCreator? = nil, title: String) {
         super.init(title: title,
                    itemProvider: itemProvider,
                    actionCreator: actionCreator,

--- a/Spellbook/TextFieldChooserDelegate.swift
+++ b/Spellbook/TextFieldChooserDelegate.swift
@@ -10,31 +10,34 @@ import ReSwift
 import UIKit
 import CoreActionSheetPicker
 
-class TextFieldChooserDelegate<A: Action, T:CaseIterable & Equatable>: NSObject, UITextFieldDelegate {
+class TextFieldChooserDelegate<A: Action, T:Equatable>: NSObject, UITextFieldDelegate {
     
     typealias ActionCreator = (T) -> A
     typealias ItemProvider = () -> T
     typealias StringGetter = (T) -> String
     typealias StringConstructor = (String) -> T
+    typealias ItemFilter = (T) -> Bool
     
     let title: String
     let main = Controllers.mainController
     
     let itemProvider: ItemProvider
-    let pickerData: [String]
+    let items: [T]
     let actionCreator: ActionCreator
     let nameGetter: StringGetter
     let textSetter: StringGetter
     let nameConstructor: StringConstructor
+    let itemFilter: ItemFilter?
     
-    init(itemProvider: @escaping ItemProvider, actionCreator: @escaping ActionCreator, nameGetter: @escaping StringGetter, textSetter: @escaping StringGetter, nameConstructor: @escaping StringConstructor, title: String) {
+    init(items: [T], title: String, itemProvider: @escaping ItemProvider, actionCreator: @escaping ActionCreator, nameGetter: @escaping StringGetter, textSetter: @escaping StringGetter, nameConstructor: @escaping StringConstructor, itemFilter: ItemFilter? = nil) {
+        self.items = items
         self.itemProvider = itemProvider
         self.actionCreator = actionCreator
         self.nameGetter = nameGetter
         self.textSetter = textSetter
         self.nameConstructor = nameConstructor
+        self.itemFilter = itemFilter
         self.title = title
-        pickerData = T.allCases.map({ nameGetter($0) })
     }
 
 
@@ -47,7 +50,14 @@ class TextFieldChooserDelegate<A: Action, T:CaseIterable & Equatable>: NSObject,
         
         // Get the index of the selected option
         let selectedItem = self.itemProvider()
-        let selectedIndex = T.allCases.firstIndex(of: selectedItem) as! Int
+        let selectedIndex: Int = items.firstIndex(of: selectedItem) ?? 0
+        
+        var itemsToUse = self.items
+        if (self.itemFilter != nil) {
+            itemsToUse = self.items.filter(self.itemFilter!)
+        }
+        let pickerData = itemsToUse.map(self.nameGetter)
+        
         
         // Create the action sheet picker
         let actionSheetPicker = ActionSheetStringPicker(title: title,
@@ -70,26 +80,43 @@ class TextFieldChooserDelegate<A: Action, T:CaseIterable & Equatable>: NSObject,
     
 }
 
+class TextFieldIterableChooserDelegate<A:Action, T:CaseIterable & Equatable>: TextFieldChooserDelegate<A,T> {
+    
+    init(title: String, itemProvider: @escaping ItemProvider, actionCreator: @escaping ActionCreator, nameGetter: @escaping StringGetter, textSetter: @escaping StringGetter, nameConstructor: @escaping StringConstructor, itemFilter: ItemFilter? = nil) {
+        let items = T.allCases.map({ $0 })
+        super.init(items: items,
+                   title: title,
+                   itemProvider: itemProvider,
+                   actionCreator: actionCreator,
+                   nameGetter: nameGetter,
+                   textSetter: textSetter,
+                   nameConstructor: nameConstructor,
+                   itemFilter: itemFilter)
+    }
+    
+}
+
 // Specific cases for types that implement NameConstructible and Unit protocols
 // These didn't seem worth their own files, since all that needs to be overwritten is the constructor
 // because the name getter and constructor come directly from the protocol
 
 
-class NameConstructibleChooserDelegate<A:Action, N:NameConstructible>: TextFieldChooserDelegate<A,N> {
+class NameConstructibleChooserDelegate<A:Action, N:NameConstructible>: TextFieldIterableChooserDelegate<A,N> {
     
     init(itemProvider: @escaping ItemProvider, actionCreator: @escaping ActionCreator, title: String) {
-        super.init(itemProvider: itemProvider,
+        super.init(title: title,
+                   itemProvider: itemProvider,
                    actionCreator: actionCreator,
                    nameGetter: { $0.displayName },
                    textSetter: { $0.displayName },
-                   nameConstructor: { return N.fromName($0) },
-                   title: title)
+                   nameConstructor: { return N.fromName($0) })
     }
 }
 
-class UnitChooserDelegate<A:Action, U:Unit> : TextFieldChooserDelegate<A,U> {
+class UnitChooserDelegate<A:Action, U:Unit> : TextFieldIterableChooserDelegate<A,U> {
     init(itemProvider: @escaping ItemProvider, actionCreator: @escaping ActionCreator, title: String) {
-        super.init(itemProvider: itemProvider,
+        super.init(title: title,
+                   itemProvider: itemProvider,
                    actionCreator: actionCreator,
                    nameGetter: { $0.pluralName },
                    textSetter: SizeUtils.unitTextGetter(U.self),
@@ -99,7 +126,6 @@ class UnitChooserDelegate<A:Action, U:Unit> : TextFieldChooserDelegate<A,U> {
                 } catch {
                     return U.defaultUnit
                 }
-            },
-               title: title)
+            })
     }
 }

--- a/Spellbook/Toast.swift
+++ b/Spellbook/Toast.swift
@@ -11,10 +11,15 @@ import Toast
 
 class Toast {
     
-    // We make our Toast messages through the main ViewController of the app
+    static func makeToast(_ message: String, duration: TimeInterval = Constants.toastDuration, controller: UIViewController) {
+        controller.view.makeToast(message, duration: duration)
+    }
+    
+    // By default, we make our Toast messages through the main ViewController of the app
     // which is the SWRevealController
     // If we ever change this, we only need to change it here
     static func makeToast(_ message: String, duration: TimeInterval = Constants.toastDuration) {
-        Controllers.revealController.view.makeToast(message, duration: duration)
+        makeToast(message, duration: duration, controller: Controllers.revealController)
     }
+
 }

--- a/Spellbook/Util.swift
+++ b/Spellbook/Util.swift
@@ -91,3 +91,31 @@ func complement<T: CaseIterable & Equatable>(items: [T]) -> [T] {
 func arrayDifference<T: Equatable>(array arr: [T], remove: [T]) -> [T] {
     return arr.filter { !remove.contains($0) }
 }
+
+func ordinal(number: Int) -> String {
+    switch number {
+    case 1:
+        return "1st"
+    case 2:
+        return "2nd"
+    case 3:
+        return "3rd"
+    default:
+        return "\(number)th"
+    }
+}
+
+func valueFrom(ordinal: String) -> Int? {
+    if ordinal == "1st" {
+        return 1
+    } else if ordinal == "2nd" {
+        return 2
+    } else if ordinal == "3rd" {
+        return 3
+    } else if ordinal.hasSuffix("th") {
+        let numberString = ordinal.dropLast(2)
+        return Int(numberString)
+    } else {
+        return nil
+    }
+}

--- a/Spellbook/Util.swift
+++ b/Spellbook/Util.swift
@@ -1,3 +1,6 @@
+// There isn't a proper Predicate type until iOS 17
+typealias Predicate<T> = (T) -> Bool
+
 func yn_to_bool(yn: String) throws -> Bool {
 	if yn == "no" {
 		return false


### PR DESCRIPTION
This PR adds functionality, exposed via a button in the spell window controller, to cast a spell. The effect of this is to use a slot of the appropriate level for the current character. The basic logic breakdown is as follows:

If the spell has rules for higher level casting, and the character has available slot(s) of the spell's level or higher, a popup controller allows selecting which spell level to cast
If the spell doesn't have higher level rules and the character's only available slots are of a higher level, a popup controller is presented asking if the user wants to upcast (for no benefit)
If the spell doesn't have higher level rules and the character has a slot of the appropriate level, a slot of that level is expended
Otherwise, a Toast message informs the user of the issue with casting (the character either doesn't have any slots, or any available slots, of an appropriate level)