### PR TITLE
Fix issue with long press callback for grid buttons

### DIFF
--- a/Spellbook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Spellbook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -13,8 +13,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReSwift/ReSwift.git",
       "state" : {
-        "revision" : "cb5c3c02f652420ef413dea41e13ac5a76b6c0fd",
-        "version" : "6.1.1"
+        "revision" : "26d3095bdf55f093501bf3a749bb2718bab671b3",
+        "version" : "6.0.0"
       }
     },
     {

--- a/Spellbook/AppReducer.swift
+++ b/Spellbook/AppReducer.swift
@@ -71,6 +71,20 @@ func specificActionReducer(action: Action, state: inout SpellbookAppState) -> Sp
         return filterDurationTypeReducer(action: action, state: &state)
     case let action as FilterRangeTypeAction:
         return filterRangeTypeReducer(action: action, state: &state)
+
+    // All-but-one visibility setting
+    case let action as FilterAllSchoolsButAction:
+        return filterAllSchoolsButReducer(action: action, state: &state)
+    case let action as FilterAllClassesButAction:
+        return filterAllClassesButReducer(action: action, state: &state)
+    case let action as FilterAllSourcebooksButAction:
+        return filterAllSourcesButReducer(action: action, state: &state)
+    case let action as FilterAllCastingTimeTypesButAction:
+        return filterAllCastingTimeTypesButReducer(action: action, state: &state)
+    case let action as FilterAllDurationTypesButAction:
+        return filterAllDurationTypesButReducer(action: action, state: &state)
+    case let action as FilterAllRangeTypesButAction:
+        return filterAllRangeTypesButReducer(action: action, state: &state)
     
     // Visibility toggling
     case let action as ToggleSchoolAction:

--- a/Spellbook/FilterGridDelegate.swift
+++ b/Spellbook/FilterGridDelegate.swift
@@ -234,7 +234,7 @@ class FilterGridRangeDelegate<T:QuantityType, A:Action, F:Action>: FilterGridDel
          longPressActionCreator: LongPressActionCreator?,
          gridWidth: CGFloat = defaultWidth) {
         self.flagSetter = flagSetter
-        super.init(getter: getter, actionCreator: actionCreator, gridWidth: gridWidth)
+        super.init(getter: getter, actionCreator: actionCreator, longPressActionCreator: longPressActionCreator, gridWidth: gridWidth)
     }
     
     

--- a/Spellbook/SortFilterTableController.swift
+++ b/Spellbook/SortFilterTableController.swift
@@ -157,25 +157,28 @@ class SortFilterTableController: UITableViewController {
         statusGetter: { tf in return store.state.profile?.sortFilterStatus.getMaterialFilter(tf) ?? true },
         actionCreator: ToggleFlagAction.material
     )
-    private let sourcebookDelegate = FilterGridFeatureDelegate<Sourcebook,ToggleSourcebookAction>(
+    private let sourcebookDelegate = FilterGridFeatureDelegate<Sourcebook,ToggleSourcebookAction,FilterAllSourcebooksButAction>(
         featuredItems: Sourcebook.coreSourcebooks,
         getter: { sb in return store.state.profile?.sortFilterStatus.getVisibility(sb) ?? true },
         actionCreator: ToggleSourcebookAction.init,
+        longPressActionCreator: { item in return FilterAllSourcebooksButAction(item: item, visible: false) },
         sortBy: Sourcebook.coreNameComparator()
     )
-    private let casterDelegate = FilterGridDelegate<CasterClass,ToggleClassAction>(
+    private let casterDelegate = FilterGridDelegate<CasterClass,ToggleClassAction,FilterAllClassesButAction>(
         getter: { cc in return store.state.profile?.sortFilterStatus.getVisibility(cc) ?? true },
         actionCreator: ToggleClassAction.init,
+        longPressActionCreator: { item in return FilterAllClassesButAction(item: item, visible: false) },
         sortBy: CasterClass.nameComparator()
     )
-    private let schoolDelegate = FilterGridDelegate<School,ToggleSchoolAction>(
+    private let schoolDelegate = FilterGridDelegate<School,ToggleSchoolAction,FilterAllSchoolsButAction>(
         getter: { s in return store.state.profile?.sortFilterStatus.getVisibility(s) ?? true },
         actionCreator: ToggleSchoolAction.init,
+        longPressActionCreator: { item in return FilterAllSchoolsButAction(item: item, visible: false) },
         sortBy: School.nameComparator()
     )
-    private var castingTimeDelegate: FilterGridRangeDelegate<CastingTimeType,ToggleCastingTimeTypeAction>?
-    private var durationDelegate: FilterGridRangeDelegate<DurationType,ToggleDurationTypeAction>?
-    private var rangeDelegate: FilterGridRangeDelegate<RangeType,ToggleRangeTypeAction>?
+    private var castingTimeDelegate: FilterGridRangeDelegate<CastingTimeType,ToggleCastingTimeTypeAction,FilterAllCastingTimeTypesButAction>?
+    private var durationDelegate: FilterGridRangeDelegate<DurationType,ToggleDurationTypeAction,FilterAllDurationTypesButAction>?
+    private var rangeDelegate: FilterGridRangeDelegate<RangeType,ToggleRangeTypeAction,FilterAllRangeTypesButAction>?
     private var gridsAndDelegates: [(UICollectionView, FilterGridProtocol)] = []
     
     // For handling touches wrt keyboard dismissal
@@ -227,20 +230,23 @@ class SortFilterTableController: UITableViewController {
         maxLevelEntry.delegate = maxLevelDelegate
         
         // Create the range delegates
-        castingTimeDelegate = FilterGridRangeDelegate<CastingTimeType,ToggleCastingTimeTypeAction>(
+        castingTimeDelegate = FilterGridRangeDelegate<CastingTimeType,ToggleCastingTimeTypeAction,FilterAllCastingTimeTypesButAction>(
             getter: { ctt in return store.state.profile?.sortFilterStatus.getVisibility(ctt) ?? true },
+            flagSetter: { b in self.castingTimeRangeVisible = b },
             actionCreator: ToggleCastingTimeTypeAction.init,
-            flagSetter: { b in self.castingTimeRangeVisible = b }
+            longPressActionCreator: { item in return FilterAllCastingTimeTypesButAction(item: item, visible: false) }
         )
-        durationDelegate = FilterGridRangeDelegate<DurationType,ToggleDurationTypeAction>(
+        durationDelegate = FilterGridRangeDelegate<DurationType,ToggleDurationTypeAction,FilterAllDurationTypesButAction>(
             getter: { dt in return store.state.profile?.sortFilterStatus.getVisibility(dt) ?? true },
+            flagSetter: { b in self.durationRangeVisible = b },
             actionCreator: ToggleDurationTypeAction.init,
-            flagSetter: { b in self.durationRangeVisible = b }
+            longPressActionCreator: { item in return FilterAllDurationTypesButAction(item: item, visible: false) }
         )
-        rangeDelegate = FilterGridRangeDelegate<RangeType,ToggleRangeTypeAction>(
+        rangeDelegate = FilterGridRangeDelegate<RangeType,ToggleRangeTypeAction,FilterAllRangeTypesButAction>(
             getter: { rt in return store.state.profile?.sortFilterStatus.getVisibility(rt) ?? true },
+            flagSetter: { b in self.rangeRangeVisible = b },
             actionCreator: ToggleRangeTypeAction.init,
-            flagSetter: { b in self.rangeRangeVisible = b }
+            longPressActionCreator: { item in return FilterAllRangeTypesButAction(item: item, visible: false) }
         )
         
         // The list of range views, and info about their table section and visibility

--- a/Spellbook/SpellbookActions.swift
+++ b/Spellbook/SpellbookActions.swift
@@ -25,6 +25,11 @@ struct FilterItemAction<T:NameConstructible>: Action {
     let visible: Bool
 }
 
+struct FilterAllButAction<T:NameConstructible>: Action {
+    let item: T
+    let visible: Bool
+}
+
 struct FilterAllAction<T:NameConstructible>: Action {
     let visible: Bool
 }
@@ -52,6 +57,13 @@ typealias FilterSourcebookAction = FilterItemAction<Sourcebook>
 typealias FilterCastingTimeTypeAction = FilterItemAction<CastingTimeType>
 typealias FilterDurationTypeAction = FilterItemAction<DurationType>
 typealias FilterRangeTypeAction = FilterItemAction<RangeType>
+
+typealias FilterAllSchoolsButAction = FilterAllButAction<School>
+typealias FilterAllClassesButAction = FilterAllButAction<CasterClass>
+typealias FilterAllSourcebooksButAction = FilterAllButAction<Sourcebook>
+typealias FilterAllCastingTimeTypesButAction = FilterAllButAction<CastingTimeType>
+typealias FilterAllDurationTypesButAction = FilterAllButAction<DurationType>
+typealias FilterAllRangeTypesButAction = FilterAllButAction<RangeType>
 
 typealias FilterAllSchoolsAction = FilterAllAction<School>
 typealias FilterAllClassesAction = FilterAllAction<CasterClass>

--- a/Spellbook/SpellbookReducers.swift
+++ b/Spellbook/SpellbookReducers.swift
@@ -82,6 +82,45 @@ func filterRangeTypeReducer(action: FilterItemAction<RangeType>, state: inout Sp
     return filterItemReducer(action: action, state: &state, visibilitySetter: SortFilterStatus.setRangeTypeVisibility)
 }
 
+fileprivate func filterAllButReducer<T:NameConstructible>(
+    action: FilterAllButAction<T>,
+    state: inout SpellbookAppState,
+    visibilitySetter: VisibilitySetter<T>
+) -> SpellbookAppState {
+    guard let status = store.state.profile?.sortFilterStatus else { return state }
+    for item in T.allCases {
+        if (item != action.item) {
+            visibilitySetter(status)(item, action.visible)
+        }
+    }
+    state.filterAndSortSpells()
+    return state
+}
+
+func filterAllSchoolsButReducer(action: FilterAllButAction<School>, state: inout SpellbookAppState) -> SpellbookAppState {
+    return filterAllButReducer(action: action, state: &state, visibilitySetter: SortFilterStatus.setSchoolVisibility)
+}
+
+func filterAllSourcesButReducer(action: FilterAllButAction<Sourcebook>, state: inout SpellbookAppState) -> SpellbookAppState {
+    return filterAllButReducer(action: action, state: &state, visibilitySetter: SortFilterStatus.setSourceVisibility)
+}
+
+func filterAllClassesButReducer(action: FilterAllButAction<CasterClass>, state: inout SpellbookAppState) -> SpellbookAppState {
+    return filterAllButReducer(action: action, state: &state, visibilitySetter: SortFilterStatus.setClassVisibility)
+}
+
+func filterAllCastingTimeTypesButReducer(action: FilterAllButAction<CastingTimeType>, state: inout SpellbookAppState) -> SpellbookAppState {
+    return filterAllButReducer(action: action, state: &state, visibilitySetter: SortFilterStatus.setCastingTimeTypeVisibility)
+}
+
+func filterAllDurationTypesButReducer(action: FilterAllButAction<DurationType>, state: inout SpellbookAppState) -> SpellbookAppState {
+    return filterAllButReducer(action: action, state: &state, visibilitySetter: SortFilterStatus.setDurationTypeVisibility)
+}
+
+func filterAllRangeTypesButReducer(action: FilterAllButAction<RangeType>, state: inout SpellbookAppState) -> SpellbookAppState {
+    return filterAllButReducer(action: action, state: &state, visibilitySetter: SortFilterStatus.setRangeTypeVisibility)
+}
+
 typealias VisibilityToggler<T:NameConstructible> = (SortFilterStatus) -> (T) -> ()
 fileprivate func toggleItemReducer<T:NameConstructible>(
     action: ToggleItemAction<T>,


### PR DESCRIPTION
This PR fixes an issue that popped up with the ReSwift update where the long press functionality doesn't work reliably in the filter grids. Rather than trying to finagle the correct simulated button presses, this PR adds a new `FilterAllButAction<T>` which we then dispatch in the delegate's long press callback. As the name suggests, the reducer for this action sets the visibility all items of the given class, except for the specified in the action, to the action-specified value (true or false).