### PR TITLE
Don't refresh spell list if spell removed from table

### DIFF
--- a/Spellbook/SpellbookReducers.swift
+++ b/Spellbook/SpellbookReducers.swift
@@ -307,7 +307,11 @@ func togglePropertyReducer(action: TogglePropertyAction, state: inout SpellbookA
             status.togglePrepared(action.spell)
             break
     }
-    if (profile.sortFilterStatus.statusFilterField == action.property) {
+    if (
+        profile.sortFilterStatus.statusFilterField == StatusFilterField.All
+            &&
+        profile.sortFilterStatus.statusFilterField == action.property
+    ) {
         state.filterAndSortSpells()
     }
     state.dirtySpellIDs = state.dirtySpellIDs + [action.spell.id]


### PR DESCRIPTION
This PR makes a modification to behavior of the spell table when looking at one of the spell lists. Currently, if one is on e.g. the Favorites list, removing a spell from the list via the table cell buttons will cause the spell to immediately disappear from the view. This can be annoying if one hits that button accidentally, since then the spell is gone from the list and can't easily be re-added. This PR causes the list to not be immediately filtered in this situation. Note that this change will match what is currently done in the Android version.