### PR TITLE
Fix higher level text for Erupting Earth

### DIFF
--- a/Data/Spells.json
+++ b/Data/Spells.json
@@ -12181,7 +12181,7 @@
         "concentration": false,
         "desc": "Choose a point you can see on the ground within range. A fountain of churned earth and stone erupts in a 20-foot cube centered on that point. Each creature in that area must make a Dexterity saving throw. A creature takes 3d12 bludgeoning damage on a failed save, or half as much damage on a successful one. Additionally, the ground in that area becomes difficult terrain until cleared away. Each 5-foot-square portion of the area requires at least 1 minute to clear by hand.",
         "duration": "Instantaneous",
-        "higher_level": "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d12 for each slot level above 2nd.",
+        "higher_level": "When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d12 for each slot level above 3rd.",
         "id": 388,
         "level": 3,
         "locations": [


### PR DESCRIPTION
This PR resolves #32 by updating the higher level text for Erupting Earth to reference the correct spell level.