### PR TITLE
Implement reducer for resetting ranges to default values

### DIFF
--- a/Spellbook/AppReducer.swift
+++ b/Spellbook/AppReducer.swift
@@ -127,6 +127,14 @@ func specificActionReducer(action: Action, state: inout SpellbookAppState) -> Sp
         return rangeValueUpdateReducer(action: action, state: &state)
     case let action as RangeUnitUpdateAction:
         return rangeUnitUpdateReducer(action: action, state: &state)
+
+    // Resetting ranges to defaults
+    case let action as CastingTimeDefaultAction:
+        return defaultCastingTimeRangeReducer(action: action, state: &state)
+    case let action as DurationDefaultAction:
+        return defaultDurationRangeReducer(action: action, state: &state)
+    case let action as RangeDefaultAction:
+        return defaultRangeRangeReducer(action: action, state: &state)
     
     // Updating filter flags
     case let action as SetFlagAction:

--- a/Spellbook/RangeView.swift
+++ b/Spellbook/RangeView.swift
@@ -82,8 +82,9 @@ class RangeView: UIView, HeightProvider {
         minUnitChoice.delegate = minUnitDelegate
         maxUnitChoice.delegate = maxUnitDelegate
         
-        // Create the function that will get the values for the unit bounds
+        // Create the functions that will get the values for the unit bounds
         boundsGetter = { () in return store.state.profile?.sortFilterStatus.getStringBounds(Q.self) ?? (0, "", 1, "") }
+        defaultBoundsGetter = { () in return store.state.profile?.sortFilterStatus.getDefaultStringBounds(Q.self) ?? (0, "", 1, "") }
         
         // Create and set the delegates for the values
         minValueDelegate = NumberFieldDelegate<ValueActionType>(

--- a/Spellbook/SortFilterStatus.swift
+++ b/Spellbook/SortFilterStatus.swift
@@ -358,6 +358,38 @@ class SortFilterStatus {
         self.maxRangeValue = maxValue
         self.maxRangeUnit = maxUnit
     }
+
+    func setCastingTimeBoundsToDefault() {
+        setCastingTimeBounds(minValue: SortFilterStatus.defaultMinCastingTimeValue,
+                             minUnit: SortFilterStatus.defaultMinCastingTimeUnit,
+                             maxValue: SortFilterStatus.defaultMaxCastingTimeValue,
+                             maxUnit: SortFilterStatus.defaultMaxCastingTimeUnit)
+    }
+    func setDurationBoundsToDefault() {
+        setDurationBounds(minValue: SortFilterStatus.defaultMinDurationValue,
+                          minUnit: SortFilterStatus.defaultMinDurationUnit,
+                          maxValue: SortFilterStatus.defaultMaxDurationValue,
+                          maxUnit: SortFilterStatus.defaultMaxDurationUnit)
+    }
+    func setRangeBoundsToDefault() {
+        setRangeBounds(minValue: SortFilterStatus.defaultMinRangeValue,
+                       minUnit: SortFilterStatus.defaultMinRangeUnit,
+                       maxValue: SortFilterStatus.defaultMaxRangeValue,
+                       maxUnit: SortFilterStatus.defaultMaxRangeUnit)
+    }
+    func setBoundsToDefault<T:QuantityType, U:Unit, Q:Quantity<T,U>>(_ type: Q.Type) {
+        switch type {
+        case is CastingTime.Type:
+            return setCastingTimeBoundsToDefault()
+        case is Duration.Type:
+            return setDurationBoundsToDefault()
+        case is Range.Type:
+            return setRangeBoundsToDefault()
+        default:
+            return
+        }
+    }
+
     private func setBoundsFromSION<U: Unit>(sion: SION, setter: BoundSetter<U>,
                                             minValueKey: String, maxValueKey: String) {
         let minValue = intFromSION(sion[minValueKey], defaultValue: 0)

--- a/Spellbook/SpellbookReducers.swift
+++ b/Spellbook/SpellbookReducers.swift
@@ -238,6 +238,22 @@ func castingTimeUnitUpdateReducer(action: CastingTimeUnitUpdateAction, state: in
     return unitUpdateReducer(action: action, state: &state, minSetter: SortFilterStatus.setMinCastingTimeUnit, maxSetter: SortFilterStatus.setMaxCastingTimeUnit)
 }
 
+func defaultRangeReducer<T: QuantityType, U: Unit, Q: Quantity<T,U>>(action: QuantityRangeDefaultAction<T,U,Q>, state: inout SpellbookAppState, type: Q.Type) -> SpellbookAppState {
+    guard let status = state.profile?.sortFilterStatus else { return state }
+    status.setBoundsToDefault(type)
+    state.filterAndSortSpells()
+    return state
+}
+func defaultCastingTimeRangeReducer(action: CastingTimeDefaultAction, state: inout SpellbookAppState) -> SpellbookAppState {
+    return defaultRangeReducer(action: action, state: &state, type: CastingTime.self)
+}
+func defaultDurationRangeReducer(action: DurationDefaultAction, state: inout SpellbookAppState) -> SpellbookAppState {
+    return defaultRangeReducer(action: action, state: &state, type: Duration.self)
+}
+func defaultRangeRangeReducer(action: RangeDefaultAction, state: inout SpellbookAppState) -> SpellbookAppState {
+    return defaultRangeReducer(action: action, state: &state, type: Range.self)
+}
+
 func setFlagFilterReducer(action: SetFlagAction, state: inout SpellbookAppState) -> SpellbookAppState {
     guard let status = state.profile?.sortFilterStatus else { return state }
     switch (action.flag) {


### PR DESCRIPTION
Currently the "Restore Default Range" buttons don't work, because it looks like I forgot to implement the reducer for this action when making the transition to ReSwift. This PR adds the necessary reducer. Thanks to @liamtimms for spotting this bug.