### PR TITLE
Add ability to create spell shortcuts

### DIFF
--- a/Spellbook.xcodeproj/project.pbxproj
+++ b/Spellbook.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		FC8256AF2DCFB3E800CBED32 /* ExportSpellListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8256AE2DCFB3E800CBED32 /* ExportSpellListController.swift */; };
 		FCB135DE2D55DCDD007EEB0B /* ParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB135DD2D55DCDD007EEB0B /* ParsingTests.swift */; };
 		FCD5CEA82E4C53CF003C4D96 /* Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD5CEA72E4C53CD003C4D96 /* Shortcuts.swift */; };
+		FCD5CEAA2E4CFC42003C4D96 /* SpellCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD5CEA92E4CFC42003C4D96 /* SpellCodec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -322,6 +323,7 @@
 		FC8256AE2DCFB3E800CBED32 /* ExportSpellListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportSpellListController.swift; sourceTree = "<group>"; };
 		FCB135DD2D55DCDD007EEB0B /* ParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingTests.swift; sourceTree = "<group>"; };
 		FCD5CEA72E4C53CD003C4D96 /* Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shortcuts.swift; sourceTree = "<group>"; };
+		FCD5CEA92E4CFC42003C4D96 /* SpellCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpellCodec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -384,6 +386,7 @@
 		397EE96721ACA86400B116B0 /* Spellbook */ = {
 			isa = PBXGroup;
 			children = (
+				FCD5CEA92E4CFC42003C4D96 /* SpellCodec.swift */,
 				FCD5CEA72E4C53CD003C4D96 /* Shortcuts.swift */,
 				FC74CE002C9FF168001AC518 /* BidirectionalMap.swift */,
 				397EE96C21ACA86400B116B0 /* Main.storyboard */,
@@ -819,6 +822,7 @@
 				8E614927241991C200842A18 /* SpellBuilder.swift in Sources */,
 				FC46ED5F2DCDC93800D42840 /* SpellListExporter.swift in Sources */,
 				8E02F76224345F6200A3050C /* YesNo.swift in Sources */,
+				FCD5CEAA2E4CFC42003C4D96 /* SpellCodec.swift in Sources */,
 				8E07AE0D2A0F708700C0487B /* ImportCharacterController.swift in Sources */,
 				8EEDC3E42AE739A60045D002 /* ConfirmNextAvailableCastController.swift in Sources */,
 				8EEA28FD297C23D8004971AD /* SpellFilter.swift in Sources */,

--- a/Spellbook.xcodeproj/project.pbxproj
+++ b/Spellbook.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		FC8256AC2DCFAABF00CBED32 /* SpellListPDFExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8256AB2DCFAABF00CBED32 /* SpellListPDFExporter.swift */; };
 		FC8256AF2DCFB3E800CBED32 /* ExportSpellListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8256AE2DCFB3E800CBED32 /* ExportSpellListController.swift */; };
 		FCB135DE2D55DCDD007EEB0B /* ParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB135DD2D55DCDD007EEB0B /* ParsingTests.swift */; };
+		FCD5CEA82E4C53CF003C4D96 /* Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD5CEA72E4C53CD003C4D96 /* Shortcuts.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -320,6 +321,7 @@
 		FC8256AB2DCFAABF00CBED32 /* SpellListPDFExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpellListPDFExporter.swift; sourceTree = "<group>"; };
 		FC8256AE2DCFB3E800CBED32 /* ExportSpellListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportSpellListController.swift; sourceTree = "<group>"; };
 		FCB135DD2D55DCDD007EEB0B /* ParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingTests.swift; sourceTree = "<group>"; };
+		FCD5CEA72E4C53CD003C4D96 /* Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shortcuts.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -382,6 +384,7 @@
 		397EE96721ACA86400B116B0 /* Spellbook */ = {
 			isa = PBXGroup;
 			children = (
+				FCD5CEA72E4C53CD003C4D96 /* Shortcuts.swift */,
 				FC74CE002C9FF168001AC518 /* BidirectionalMap.swift */,
 				397EE96C21ACA86400B116B0 /* Main.storyboard */,
 				8EEDC3E12ADA69170045D002 /* HigherLevelSlotController.swift */,
@@ -864,6 +867,7 @@
 				8E19DA5A257D6D46002B4F43 /* MessageDialogController.swift in Sources */,
 				FC8256AC2DCFAABF00CBED32 /* SpellListPDFExporter.swift in Sources */,
 				8E61491F241991C200842A18 /* Transitions.swift in Sources */,
+				FCD5CEA82E4C53CF003C4D96 /* Shortcuts.swift in Sources */,
 				8E6E2B8428E9FF2400AA6483 /* SpellbookAppState.swift in Sources */,
 				8E6148E5241991C200842A18 /* Duration.swift in Sources */,
 				8E92CC67243BD49900EB78B2 /* NumberFieldDelegate.swift in Sources */,

--- a/Spellbook/AppDelegate.swift
+++ b/Spellbook/AppDelegate.swift
@@ -45,24 +45,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-       
-        if shortcutItem.type.starts(with: "Open") {
-            print("Spell shortcut")
+        
+        guard let info = shortcutItem.userInfo else {
+            completionHandler(false)
+            return
+        }
+        
+        if let spellJSON = info["spell"], let type = info["type"], type as? String == "SpellView" {
             let codec = SpellCodec()
-            let userInfo = shortcutItem.userInfo
-            guard let json = userInfo?["spell"] else { completionHandler(false); return }
-            let jsonString = json as! String
+            let jsonString = spellJSON as! String
             let sion = SION(json: jsonString)
             let spell = codec.parseSpell(sion: sion)
-            
+
             let storyboard = UIStoryboard(name: "Main", bundle: nil)
             let controller = storyboard.instantiateViewController(withIdentifier: "spellWindow") as! SpellWindowController
+            controller.modalPresentationStyle = .fullScreen
+            controller.transitioningDelegate = controller
             controller.fromShortcut = true
             Controllers.mainNavController.present(controller, animated: true, completion: { controller.spell = spell })
             completionHandler(true)
+        } else {
+            completionHandler(false)
         }
         
-        completionHandler(false)
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/Spellbook/AppDelegate.swift
+++ b/Spellbook/AppDelegate.swift
@@ -43,6 +43,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         return true
     }
+    
+    func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+       
+        if shortcutItem.type.starts(with: "Open") {
+            print("Spell shortcut")
+            let codec = SpellCodec()
+            let userInfo = shortcutItem.userInfo
+            guard let json = userInfo?["spell"] else { completionHandler(false); return }
+            let jsonString = json as! String
+            let sion = SION(json: jsonString)
+            let spell = codec.parseSpell(sion: sion)
+            
+            let storyboard = UIStoryboard(name: "Main", bundle: nil)
+            let controller = storyboard.instantiateViewController(withIdentifier: "spellWindow") as! SpellWindowController
+            controller.fromShortcut = true
+            Controllers.mainNavController.present(controller, animated: true, completion: { controller.spell = spell })
+            completionHandler(true)
+        }
+        
+        completionHandler(false)
+    }
 
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -1396,19 +1396,19 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rename Character" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c9W-6x-xK1">
-                                <rect key="frame" x="103" y="93" width="208" height="35.333333333333343"/>
+                                <rect key="frame" x="103" y="93" width="208" height="35"/>
                                 <fontDescription key="fontDescription" name="CloisterBlack-Light" family="Cloister Black" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u2G-q7-d8v">
-                                <rect key="frame" x="207" y="133.33333333333334" width="0.0" height="0.0"/>
+                                <rect key="frame" x="207" y="133" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="H08-Dk-PUF">
-                                <rect key="frame" x="82" y="138.33333333333334" width="250" height="50"/>
+                                <rect key="frame" x="82" y="138" width="250" height="50"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="tintColor" name="DefaultFontColor"/>
                                 <constraints>
@@ -1948,7 +1948,7 @@
                             <tableViewSection headerTitle="Filter Options" id="nkt-s2-SOP" userLabel="Filter Options">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="hzf-AI-tqn">
-                                        <rect key="frame" x="0.0" y="225.33333015441897" width="414" height="43.999999999999972"/>
+                                        <rect key="frame" x="0.0" y="225.33333015441895" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hzf-AI-tqn" id="14f-bY-mAc">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -404,6 +404,7 @@
                         <subviews>
                             <imageView opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="N4d-fT-FYa">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </imageView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sbA-fH-uxW">
                                 <rect key="frame" x="5" y="2" width="404" height="894"/>
@@ -1948,7 +1949,7 @@
                             <tableViewSection headerTitle="Filter Options" id="nkt-s2-SOP" userLabel="Filter Options">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="hzf-AI-tqn">
-                                        <rect key="frame" x="0.0" y="225.33333015441895" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="225.33333015441897" width="414" height="43.999999999999972"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hzf-AI-tqn" id="14f-bY-mAc">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -409,6 +409,7 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sbA-fH-uxW">
                                 <rect key="frame" x="5" y="2" width="404" height="894"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="separatorColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="sectionIndexBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
@@ -1586,7 +1587,7 @@
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="zy4-VM-y91"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                     <connections>
                         <segue destination="dND-bH-GRC" kind="custom" identifier="sw_front" customClass="SWRevealViewControllerSegueSetController" id="VDX-Vj-T65"/>

--- a/Spellbook/Ruleset.swift
+++ b/Spellbook/Ruleset.swift
@@ -8,17 +8,17 @@
 
 import Foundation
 
-enum Ruleset {
+enum Ruleset: Int, NameConstructible {
     case Rules2014, Rules2024, RulesCreated
     
-    private static let nameMap: [String:Ruleset] = [
-        "2014": Rules2014,
-        "2024": Rules2024,
-        "created": RulesCreated,
-    ]
-    
-    static func fromName(_ name: String?) -> Ruleset? {
-        guard var key = name?.lowercased() else { return nil }
-        return Ruleset.nameMap[key]
+    internal static var displayNameMap = EnumMap<Ruleset, String> { e in
+        switch(e) {
+        case .Rules2014:
+            return "2014"
+        case .Rules2024:
+            return "2024"
+        case .RulesCreated:
+            return "Created"
+        }
     }
 }

--- a/Spellbook/Shortcuts.swift
+++ b/Spellbook/Shortcuts.swift
@@ -35,12 +35,14 @@ func addShortcut(
    
     UserDefaults.standard.set(order, forKey: SHORTCUT_STORAGE_KEY)
     
+    
     let existingShortcuts = order.map { shortcutTitle in
         // Try to reuse the existing shortcut’s data if it exists in current list
-        if let current = application.shortcutItems?.first(where: { $0.localizedTitle == shortcutTitle }),
-           shortcutTitle != title {
+        if let current = application.shortcutItems?.first(where: { $0.localizedTitle == shortcutTitle }) {
             return current
         }
+        
+        let info = userInfo as [String: NSSecureCoding]?
         
         if shortcutTitle == title {
             return UIApplicationShortcutItem(
@@ -48,7 +50,7 @@ func addShortcut(
                 localizedTitle: title,
                 localizedSubtitle: subtitle,
                 icon: UIApplicationShortcutIcon(type: iconType),
-                userInfo: userInfo as [String: NSSecureCoding]?
+                userInfo: info
             )
         }
         
@@ -57,7 +59,7 @@ func addShortcut(
             localizedTitle: shortcutTitle,
             localizedSubtitle: nil,
             icon: UIApplicationShortcutIcon(type: iconType),
-            userInfo: nil
+            userInfo: info
         )
     }
             
@@ -65,12 +67,19 @@ func addShortcut(
 }
 
 func addSpellShortcut(spell: Spell) {
+    let codec = SpellCodec()
+    let sion = codec.toSION(spell)
+    
+    var jsonString = String(sion.json)
+    fixEscapeCharacters(&jsonString)
+    let type = "Open \(spell.name)"
+    
     addShortcut(
-        type: "spellView",
+        type: type,
         title: spell.name,
         subtitle: nil,
         userInfo: [
-            "spell": spell
+            "spell": jsonString as NSString
         ]
     )
 }

--- a/Spellbook/Shortcuts.swift
+++ b/Spellbook/Shortcuts.swift
@@ -63,3 +63,14 @@ func addShortcut(
             
     application.shortcutItems = existingShortcuts
 }
+
+func addSpellShortcut(spell: Spell) {
+    addShortcut(
+        type: "spellView",
+        title: spell.name,
+        subtitle: nil,
+        userInfo: [
+            "spell": spell
+        ]
+    )
+}

--- a/Spellbook/Shortcuts.swift
+++ b/Spellbook/Shortcuts.swift
@@ -36,10 +36,10 @@ func addShortcut(
     order.removeAll { $0.title == title }
     
     if order.count >= MAX_SHORTCUTS {
-        order.removeFirst(order.count - MAX_SHORTCUTS + 1)
+        order.removeLast(order.count - MAX_SHORTCUTS + 1)
     }
     
-    order.append(ShortcutInfo(type: type, title: title))
+    order.insert(ShortcutInfo(type: type, title: title), at: 0)
     
     let orderedInfo = order.compactMap { try? PropertyListEncoder().encode($0) }
     UserDefaults.standard.set(orderedInfo, forKey: SHORTCUT_STORAGE_KEY)

--- a/Spellbook/Shortcuts.swift
+++ b/Spellbook/Shortcuts.swift
@@ -25,7 +25,7 @@ func addShortcut(
     let application = UIApplication.shared
     var order = getOrderedShortcuts()
     
-    order.removeAll { $0 == type }
+    order.removeAll { $0 == title }
     
     if order.count >= MAX_SHORTCUTS {
         order.removeFirst(order.count - MAX_SHORTCUTS + 1)
@@ -35,14 +35,14 @@ func addShortcut(
    
     UserDefaults.standard.set(order, forKey: SHORTCUT_STORAGE_KEY)
     
-    let existingShortcuts = order.map { shortcutType in
+    let existingShortcuts = order.map { shortcutTitle in
         // Try to reuse the existing shortcut’s data if it exists in current list
-        if let current = application.shortcutItems?.first(where: { $0.type == shortcutType }),
-           shortcutType != type {
+        if let current = application.shortcutItems?.first(where: { $0.localizedTitle == shortcutTitle }),
+           shortcutTitle != title {
             return current
         }
         
-        if shortcutType == type {
+        if shortcutTitle == title {
             return UIApplicationShortcutItem(
                 type: type,
                 localizedTitle: title,
@@ -53,10 +53,10 @@ func addShortcut(
         }
         
         return UIApplicationShortcutItem(
-            type: shortcutType,
-            localizedTitle: shortcutType,
+            type: type,
+            localizedTitle: shortcutTitle,
             localizedSubtitle: nil,
-            icon: UIApplicationShortcutIcon(type: .compose),
+            icon: UIApplicationShortcutIcon(type: iconType),
             userInfo: nil
         )
     }

--- a/Spellbook/Shortcuts.swift
+++ b/Spellbook/Shortcuts.swift
@@ -1,0 +1,65 @@
+//
+//  Shortcuts.swift
+//  Spellbook
+//
+//  Created by Jonathan Carifio on 8/13/25.
+//  Copyright © 2025 Jonathan Carifio. All rights reserved.
+//
+
+import UIKit
+
+fileprivate let MAX_SHORTCUTS = 4
+fileprivate let SHORTCUT_STORAGE_KEY = "dynamicShortcutOrder"
+
+func getOrderedShortcuts() -> [String] {
+    return UserDefaults.standard.stringArray(forKey: SHORTCUT_STORAGE_KEY) ?? []
+}
+
+func addShortcut(
+    type: String,
+    title: String,
+    subtitle: String? = nil,
+    iconType: UIApplicationShortcutIcon.IconType = .favorite,
+    userInfo: [String: NSSecureCoding]? = nil
+) {
+    let application = UIApplication.shared
+    var order = getOrderedShortcuts()
+    
+    order.removeAll { $0 == type }
+    
+    if order.count >= MAX_SHORTCUTS {
+        order.removeFirst(order.count - MAX_SHORTCUTS + 1)
+    }
+    
+    order.append(type)
+   
+    UserDefaults.standard.set(order, forKey: SHORTCUT_STORAGE_KEY)
+    
+    let existingShortcuts = order.map { shortcutType in
+        // Try to reuse the existing shortcut’s data if it exists in current list
+        if let current = application.shortcutItems?.first(where: { $0.type == shortcutType }),
+           shortcutType != type {
+            return current
+        }
+        
+        if shortcutType == type {
+            return UIApplicationShortcutItem(
+                type: type,
+                localizedTitle: title,
+                localizedSubtitle: subtitle,
+                icon: UIApplicationShortcutIcon(type: iconType),
+                userInfo: userInfo as [String: NSSecureCoding]?
+            )
+        }
+        
+        return UIApplicationShortcutItem(
+            type: shortcutType,
+            localizedTitle: shortcutType,
+            localizedSubtitle: nil,
+            icon: UIApplicationShortcutIcon(type: .compose),
+            userInfo: nil
+        )
+    }
+            
+    application.shortcutItems = existingShortcuts
+}

--- a/Spellbook/SpellCodec.swift
+++ b/Spellbook/SpellCodec.swift
@@ -45,7 +45,9 @@ class SpellCodec {
     private static let CONCENTRATION_PREFIX = "Up to"
     private static let RITUAL_SUFFIX = " or Ritual"
 
-    func parseSpell(sion: SION, builder: SpellBuilder) -> Spell {
+    func parseSpell(sion: SION, builder spellBuilder: SpellBuilder? = nil) -> Spell {
+        
+        let builder = spellBuilder ?? SpellBuilder()
 
         // Set the values that need no/trivial parsing
         builder.setID(intGetter(sion, key: SpellCodec.ID_KEY))

--- a/Spellbook/SpellCodec.swift
+++ b/Spellbook/SpellCodec.swift
@@ -136,7 +136,7 @@ class SpellCodec {
         }
 
         let rulesetName = sion[SpellCodec.RULESET_KEY].string
-        let ruleset = Ruleset.fromName(rulesetName) ?? Ruleset.Rules2014
+        let ruleset = rulesetName != nil ? Ruleset.fromName(rulesetName!) : Ruleset.Rules2014
         builder.setRuleset(ruleset)
         
         return builder.buildAndReset()
@@ -149,10 +149,39 @@ class SpellCodec {
         sion[SpellCodec.NAME_KEY].string = spell.name
         sion[SpellCodec.DESCRIPTION_KEY].string = spell.description
         sion[SpellCodec.HIGHER_LEVEL_KEY].string = spell.higherLevel
-        
+        sion[SpellCodec.LEVEL_KEY].int = spell.level
+        sion[SpellCodec.SCHOOL_KEY].string = spell.school.displayName
+
         sion[SpellCodec.RANGE_KEY].string = spell.range.string()
         sion[SpellCodec.DURATION_KEY].string = spell.duration.string()
-        
+        sion[SpellCodec.CASTING_TIME_KEY].string = spell.castingTime.string()
+
+        sion[SpellCodec.RITUAL_KEY].bool = spell.ritual
+        sion[SpellCodec.CONCENTRATION_KEY].bool = spell.concentration
+
+        sion[SpellCodec.MATERIAL_KEY].string = spell.materials
+        sion[SpellCodec.ROYALTY_KEY].string = spell.royalties
+
+        var components: [String] = []
+        if spell.verbal { components.append("V") }
+        if spell.somatic { components.append("S") }
+        if spell.material { components.append("M") }
+        if spell.royalty { components.append("R") }
+
+        sion[SpellCodec.CLASSES_KEY].array = spell.classes.map { SION($0.displayName) }
+        sion[SpellCodec.SUBCLASSES_KEY].array = spell.subclasses.map { SION($0.displayName) }
+        sion[SpellCodec.TCE_EXPANDED_CLASSES_KEY].array = spell.tashasExpandedClasses.map { SION($0.displayName) }
+
+        sion[SpellCodec.RULESET_KEY].string = spell.ruleset.displayName
+
+        sion[SpellCodec.LOCATIONS_KEY].array = spell.locations.map {
+            entry in
+            return [
+                SION.Key(SpellCodec.SOURCEBOOK_KEY): SION(entry.key.displayName),
+                SION.Key(SpellCodec.PAGE_KEY): SION(entry.value),
+            ]
+        }
+
         return sion
     }
 }

--- a/Spellbook/SpellCodec.swift
+++ b/Spellbook/SpellCodec.swift
@@ -1,0 +1,144 @@
+//
+//  SpellCodec.swift
+//  Spellbook
+//
+//  Created by Jonathan Carifio on 8/13/25.
+//  Copyright © 2025 Jonathan Carifio. All rights reserved.
+//
+
+
+//
+//  SpellCodec.swift
+//  Spellbook
+//
+//  Created by Jonathan Carifio on 5/31/24.
+//  Copyright © 2024 Jonathan Carifio. All rights reserved.
+//
+
+import Foundation
+
+class SpellCodec {
+    private static let ID_KEY = "id"
+    private static let NAME_KEY = "name"
+    private static let PAGE_KEY = "page"
+    private static let DURATION_KEY = "duration"
+    private static let RANGE_KEY = "range"
+    private static let RITUAL_KEY = "ritual"
+    private static let CONCENTRATION_KEY = "concentration"
+    private static let LEVEL_KEY = "level"
+    private static let CASTING_TIME_KEY = "casting_time"
+    private static let MATERIAL_KEY = "material"
+    private static let ROYALTY_KEY = "royalty"
+    private static let COMPONENTS_KEY = "components"
+    private static let DESCRIPTION_KEY = "desc"
+    private static let HIGHER_LEVEL_KEY = "higher_level"
+    private static let SCHOOL_KEY = "school"
+    private static let CLASSES_KEY = "classes"
+    private static let SUBCLASSES_KEY = "subclasses"
+    private static let TCE_EXPANDED_CLASSES_KEY = "tce_expanded_classes"
+    private static let SOURCEBOOK_KEY = "sourcebook"
+    private static let LOCATIONS_KEY = "locations"
+    private static let RULESET_KEY = "ruleset"
+    
+    private static let COMPONENT_STRINGS = ["V", "S", "M", "R"]
+    
+    private static let CONCENTRATION_PREFIX = "Up to"
+    private static let RITUAL_SUFFIX = " or Ritual"
+
+    func parseSpell(sion: SION, b: SpellBuilder) -> Spell {
+
+        // Set the values that need no/trivial parsing
+        b.setID(intGetter(sion, key: SpellCodec.ID_KEY))
+            .setName(sion[SpellCodec.NAME_KEY].string!)
+            .setLevel(intGetter(sion, key: SpellCodec.LEVEL_KEY))
+            .setSchool(School.fromName(sion[SpellCodec.SCHOOL_KEY].string!))
+        
+        let locations = sion[SpellCodec.LOCATIONS_KEY]
+        if let array = locations.array {
+            for location in array {
+                if let sb = Sourcebook.fromCode(location[SpellCodec.SOURCEBOOK_KEY].string) {
+                    b.addLocation(sourcebook: sb, page: intGetter(location, key: SpellCodec.PAGE_KEY))
+                }
+            }
+        }
+        let durationString = sion[SpellCodec.DURATION_KEY].string! // Use this again later for the concentration part
+        do {
+            try b.setDuration(Duration.fromString(durationString))
+        } catch {
+            b.setDuration(Duration())
+        }
+        
+        do {
+            try b.setRange(Range.fromString(sion[SpellCodec.RANGE_KEY].string!))
+        } catch {
+            b.setRange(Range())
+        }
+        
+        if (durationString.starts(with: SpellCodec.CONCENTRATION_PREFIX)) {
+            b.setConcentration(true)
+        } else {
+            b.setConcentration(sion[SpellCodec.CONCENTRATION_KEY].bool ?? false)
+        }
+        
+        var castingTimeString = sion[SpellCodec.CASTING_TIME_KEY].string!
+        let endsWithRitual = castingTimeString.hasSuffix(SpellCodec.RITUAL_SUFFIX)
+        if (endsWithRitual) {
+            let finalIndex = castingTimeString.count - SpellCodec.RITUAL_SUFFIX.count - 1
+            castingTimeString = castingTimeString[...finalIndex]
+        }
+        
+        do {
+            try b.setCastingTime(CastingTime.fromString(castingTimeString))
+        } catch {
+            b.setCastingTime(CastingTime())
+        }
+        
+        b.setRitual(sion[SpellCodec.RITUAL_KEY].bool ?? endsWithRitual)
+        
+        b.setMaterials(sion[SpellCodec.MATERIAL_KEY].string ?? "")
+        b.setRoyalties(sion[SpellCodec.ROYALTY_KEY].string ?? "")
+        
+        // components
+        let components = sion[SpellCodec.COMPONENTS_KEY]
+        for (_, v) in components {
+            if v == "V" { b.setVerbal(true); continue }
+            if v == "S" { b.setSomatic(true); continue }
+            if v == "M" { b.setMaterial(true); continue }
+            if v == "R" { b.setRoyalty(true); continue }
+        }
+        
+        // Description
+        b.setDescription(sion[SpellCodec.DESCRIPTION_KEY].string!)
+        
+        // Higher level description
+        let hlString = sion[SpellCodec.HIGHER_LEVEL_KEY].string ?? ""
+        b.setHigherLevelDesc(hlString)
+        
+        let classes = sion[SpellCodec.CLASSES_KEY]
+        if let array = classes.array {
+            for cls in array {
+                b.addClass(CasterClass.fromName(cls.string!))
+            }
+        }
+        
+        let subclasses = sion[SpellCodec.SUBCLASSES_KEY]
+        if let array = subclasses.array {
+            for subclass in array {
+                b.addSubclass(SubClass.fromName(subclass.string!))
+            }
+        }
+        
+        let tceExpandedClasses = sion[SpellCodec.TCE_EXPANDED_CLASSES_KEY]
+        if let array = tceExpandedClasses.array {
+            for cls in array {
+                b.addTashasExpandedClass(CasterClass.fromName(cls.string!))
+            }
+        }
+
+        let rulesetName = sion[SpellCodec.RULESET_KEY].string
+        let ruleset = Ruleset.fromName(rulesetName) ?? Ruleset.Rules2014
+        b.setRuleset(ruleset)
+        
+        return b.buildAndReset()
+    }
+}

--- a/Spellbook/SpellParse.swift
+++ b/Spellbook/SpellParse.swift
@@ -137,9 +137,9 @@ func parseSpell(obj: SION, b: SpellBuilder) -> Spell {
             b.addTashasExpandedClass(CasterClass.fromName(name.string!))
         }
     }
-    
+
     let rulesetName = obj["ruleset"].string
-    let ruleset = Ruleset.fromName(rulesetName) ?? Ruleset.Rules2014
+    let ruleset = rulesetName != nil ? Ruleset.fromName(rulesetName!) : Ruleset.Rules2014
     b.setRuleset(ruleset)
     
 	return b.buildAndReset()

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -300,15 +300,6 @@ class SpellWindowController: UIViewController {
         }
     }
     
-    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        super.dismiss(animated: flag, completion: completion)
-        if (fromShortcut) {
-            // If we're opening from a shortcut, this should be a standalone view
-            // and so I think it makes sense to directly exit the application here
-            exit(0)
-        }
-    }
-
 }
 
 

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -79,10 +79,22 @@ class SpellWindowController: UIViewController {
     var spell = Spell() {
         didSet { setSpell(spell) }
     }
+    
+    var fromShortcut: Bool
+    
+    init(shortcut: Bool = false) {
+        self.fromShortcut = shortcut
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        self.fromShortcut = false
+        super.init(coder: coder)
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         // We close the window on a swipe to the right
         let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(respondToSwipeGesture))
         swipeRight.direction = UISwipeGestureRecognizer.Direction.right
@@ -108,6 +120,12 @@ class SpellWindowController: UIViewController {
         })
         
         castButton.addTarget(self, action: #selector(self.onCastClicked), for: UIControl.Event.touchUpInside)
+        
+        if fromShortcut {
+            for button in [favoriteButton, preparedButton, knownButton, castButton] {
+                button?.isHidden = true
+            }
+        }
         
         // Set the content view to fill the screen
         contentView.frame = UIScreen.main.bounds
@@ -141,16 +159,25 @@ class SpellWindowController: UIViewController {
     
     func setSpell(_ spell: Spell) {
         
+        print("Starting setSpell")
+        print(spell)
+        
         // Get the character profile
         guard let profile = store.state.profile else { return }
         
         var needsLayoutUpdate = false
         
+        print("Got profile")
+        
         // Don't show the cast button for cantrips
-        castButton.isHidden = spell.level == 0
+        castButton.isHidden = fromShortcut || spell.level == 0
+        
+        print("Hid cast button for cantrip")
         
         // Set the text on the name label
         spellNameLabel.text = spell.name
+        
+        print("Set text")
         
         // Do the same for the body of the spell text
         schoolLevelLabel.attributedText = schoolLevelText(spell)
@@ -171,7 +198,7 @@ class SpellWindowController: UIViewController {
         rangeLabel.attributedText = propertyText(name: "Range", text: spell.range.string())
         concentrationLabel.attributedText = propertyText(name: "Concentration", text: bool_to_yn(yn: spell.concentration))
         classesLabel.attributedText = propertyText(name: "Classes", text: spell.classesString())
-        if (profile.sortFilterStatus.useTashasExpandedLists && spell.tashasExpandedClasses.count > 0) {
+        if fromShortcut || (profile.sortFilterStatus.useTashasExpandedLists && spell.tashasExpandedClasses.count > 0) {
             expandedClassesLabel.attributedText = propertyText(name: "TCE Expanded Classes", text: spell.tashasExpandedClassesString())
         }
         descriptionLabel.attributedText = propertyText(name: "Description", text: spell.description, addLine: true)
@@ -179,10 +206,14 @@ class SpellWindowController: UIViewController {
             higherLevelLabel.attributedText = propertyText(name: "Higher level", text: spell.higherLevel, addLine: true)
         }
         
+        print("Set labels")
+
         // Set the spell buttons to the correct state
         favoriteButton.set(profile.spellFilterStatus.isFavorite(spell))
         preparedButton.set(profile.spellFilterStatus.isPrepared(spell))
         knownButton.set(profile.spellFilterStatus.isKnown(spell))
+        
+        print("Set buttons")
         
         // Set the scroll view content size
         scrollView.contentSize = self.view.frame.size
@@ -266,6 +297,15 @@ class SpellWindowController: UIViewController {
         
         if let toast = message {
             self.view.makeToast(toast, duration: Constants.toastDuration)
+        }
+    }
+    
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: completion)
+        if (fromShortcut) {
+            // If we're opening from a shortcut, this should be a standalone view
+            // and so I think it makes sense to directly exit the application here
+            exit(0)
         }
     }
 

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -159,25 +159,16 @@ class SpellWindowController: UIViewController {
     
     func setSpell(_ spell: Spell) {
         
-        print("Starting setSpell")
-        print(spell)
-        
         // Get the character profile
         guard let profile = store.state.profile else { return }
         
         var needsLayoutUpdate = false
         
-        print("Got profile")
-        
         // Don't show the cast button for cantrips
         castButton.isHidden = fromShortcut || spell.level == 0
         
-        print("Hid cast button for cantrip")
-        
         // Set the text on the name label
         spellNameLabel.text = spell.name
-        
-        print("Set text")
         
         // Do the same for the body of the spell text
         schoolLevelLabel.attributedText = schoolLevelText(spell)
@@ -206,18 +197,13 @@ class SpellWindowController: UIViewController {
             higherLevelLabel.attributedText = propertyText(name: "Higher level", text: spell.higherLevel, addLine: true)
         }
         
-        print("Set labels")
-
         // Set the spell buttons to the correct state
         favoriteButton.set(profile.spellFilterStatus.isFavorite(spell))
         preparedButton.set(profile.spellFilterStatus.isPrepared(spell))
         knownButton.set(profile.spellFilterStatus.isKnown(spell))
         
-        print("Set buttons")
-        
         // Set the scroll view content size
         scrollView.contentSize = self.view.frame.size
-        //print("Scroll enabled: \(scrollView.isScrollEnabled)")
         
         // Update the constraints if necessary
         if needsLayoutUpdate {

--- a/Spellbook/Util.swift
+++ b/Spellbook/Util.swift
@@ -19,14 +19,14 @@ func bool_to_yn(yn: Bool) -> String {
 	}
 }
 
+let defaultEscapeReplacements = [
+    "\\'" : "\'",
+    "\\\\" : "\\",
+    "\\n" : "\n",
+    "\\t" : "\t"
+]
 
-func fixEscapeCharacters(_ str : inout String) {
-    let replacements : [String : String] = [
-        "\\'" : "\'",
-        "\\\\" : "\\",
-        "\\n" : "\n",
-        "\\t" : "\t"
-    ]
+func fixEscapeCharacters(_ str : inout String, replacements: [String:String] = defaultEscapeReplacements) {
     for x in replacements {
         str = str.replacingOccurrences(of: x.0, with: x.1)
     }

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -545,6 +545,13 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         let spell = spells[indexPath.row]
         cell.spell = spell
         
+        setupCell(cell: cell, spell: spell)
+        
+        return cell
+    }
+        
+    func setupCell(cell: SpellDataCell, spell: Spell) {
+        
         // Cell formatting
         cell.layoutMargins = UIEdgeInsets(top: 2, left: 0, bottom: 2, right: 0)
         cell.selectionStyle = .gray
@@ -585,20 +592,39 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         cell.knownButton.setCallback({
             store.dispatch(TogglePropertyAction(spell: cell.spell, property: .Known, markDirty: false))
         })
-
-        return cell
     }
     
     private func makeTargetedPreview(for configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         guard let indexPath = configuration.identifier as? IndexPath else { return nil }
         guard let cell = spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return nil }
+        cell.contentView.backgroundColor = UIColor.lightGray
         return UITargetedPreview(view: cell.contentView)
+    }
+    
+    func tableView(_ tableView: UITableView, willDisplayContextMenu configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+        guard let indexPath = configuration.identifier as? IndexPath else { return }
+        guard let cell = self.spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return }
+        cell.contentView.backgroundColor = UIColor.white
+    }
+        
+    func tableView(_ tableView: UITableView, willEndContextMenuInteraction configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+        animator?.addCompletion {
+            guard let indexPath = configuration.identifier as? IndexPath else { return }
+            guard let cell = self.spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return }
+            cell.contentView.backgroundColor = UIColor.clear
+        }
     }
     
     func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         return makeTargetedPreview(for: configuration)
     }
     
+//    func tableView(_ tableView: UITableView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+//        let preview = makeTargetedPreview(for: configuration)
+//        preview?.view.backgroundColor = UIColor.clear
+//        return preview
+//    }
+
     func tableView(_ tableView: UITableView,
                    contextMenuConfigurationForRowAt indexPath: IndexPath,
                    point: CGPoint) -> UIContextMenuConfiguration? {

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -594,24 +594,31 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         })
     }
     
-    private func makeTargetedPreview(for configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+    private func makeTargetedPreview(for configuration: UIContextMenuConfiguration, backgroundColor: UIColor? = nil) -> UITargetedPreview? {
         guard let indexPath = configuration.identifier as? IndexPath else { return nil }
         guard let cell = spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return nil }
         cell.contentView.backgroundColor = UIColor.lightGray
-        return UITargetedPreview(view: cell.contentView)
+        let preview = UITargetedPreview(view: cell.contentView)
+        if (backgroundColor != nil) {
+            preview.view.backgroundColor = backgroundColor
+        }
+        return preview
+    }
+    
+    func setCellBackgroundColor(indexPath: IndexPath, color: UIColor) {
+        guard let cell = spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return }
+        cell.contentView.backgroundColor = color
     }
     
     func tableView(_ tableView: UITableView, willDisplayContextMenu configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
         guard let indexPath = configuration.identifier as? IndexPath else { return }
-        guard let cell = self.spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return }
-        cell.contentView.backgroundColor = UIColor.white
+        setCellBackgroundColor(indexPath: indexPath, color: UIColor.white)
     }
         
     func tableView(_ tableView: UITableView, willEndContextMenuInteraction configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
         animator?.addCompletion {
             guard let indexPath = configuration.identifier as? IndexPath else { return }
-            guard let cell = self.spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return }
-            cell.contentView.backgroundColor = UIColor.clear
+            self.setCellBackgroundColor(indexPath: indexPath, color: UIColor.clear)
         }
     }
     

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -589,6 +589,37 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         return cell
     }
     
+    private func makeTargetedPreview(for configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        guard let indexPath = configuration.identifier as? IndexPath else { return nil }
+        guard let cell = spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return nil }
+        return UITargetedPreview(view: cell.contentView)
+    }
+    
+    func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        return makeTargetedPreview(for: configuration)
+    }
+    
+    func tableView(_ tableView: UITableView,
+                   contextMenuConfigurationForRowAt indexPath: IndexPath,
+                   point: CGPoint) -> UIContextMenuConfiguration? {
+        let cell = tableView.cellForRow(at: indexPath) as! SpellDataCell
+        let spell = cell.spell
+        return UIContextMenuConfiguration(
+            identifier: indexPath as NSCopying,
+            previewProvider: nil,
+            actionProvider: {
+                suggestedActions in
+                let shortcutAction =
+                UIAction(
+                    title: "Create Shortcut",
+                    image: UIImage(named: "book_empty.png")) {
+                        action in addSpellShortcut(spell: spell)
+                    }
+                return UIMenu(title: "Spell Options", children: [shortcutAction])
+            }
+        )
+    }
+    
     func sort() {
         store.dispatch(SortNeededAction())
     }

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -592,6 +592,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     private func makeTargetedPreview(for configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         guard let indexPath = configuration.identifier as? IndexPath else { return nil }
         guard let cell = spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return nil }
+        cell.contentView.backgroundColor = UIColor.white
         return UITargetedPreview(view: cell.contentView)
     }
     
@@ -612,7 +613,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
                 let shortcutAction =
                 UIAction(
                     title: "Create Shortcut",
-                    image: UIImage(named: "book_empty.png")) {
+                    image: UIImage(named: "book_empty.png")?.inverseImage(cgResult: true))  {
                         action in addSpellShortcut(spell: spell)
                     }
                 return UIMenu(title: "Spell Options", children: [shortcutAction])

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -592,7 +592,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     private func makeTargetedPreview(for configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         guard let indexPath = configuration.identifier as? IndexPath else { return nil }
         guard let cell = spellTable.cellForRow(at: indexPath) as? SpellDataCell else { return nil }
-        cell.contentView.backgroundColor = UIColor.white
         return UITargetedPreview(view: cell.contentView)
     }
     


### PR DESCRIPTION
This PR is the equivalent of https://github.com/Carifio24/SpellbookApp/pull/156 - that is, it adds the ability to create shortcut items that open directly to specific spells. I don't think this is as useful on iOS as it is on Android (where you can turn a shortcut into its own icon on the start screen), but I still wanted to add this as an option. This PR limits the number of available shortcut items to four, and pushes off the oldest item (if necessary) to accomodate a new one.

Similar to the Android version, the app knows when we're accessing a spell from a shortcut, and adjusts the view to be character-independent. However, since iOS doesn't have a natural way to "close" an application, if the user swipes back out of the spell, we go to the normal starting app view, just as if they'd opened it from the icon.

Unlike on Android, there wasn't as much of a choice necessary for how to access this, as we just use the built-in iOS table context menu functionality. I did have to do a bit of cell manipulation when highlighting/opening the context menu for a spell .in the spell table, since without it the cell background became black and made the text unreadable. This wasn't necessary for the context menu creation for character cells - I suspect the difference is something about the background settings of the main view controller (or the reveal controller), but I wasn't able to find a way to avoid this by tweaking their settings.