### PR TITLE
Adjustments for iPad

### DIFF
--- a/Spellbook.xcodeproj/project.pbxproj
+++ b/Spellbook.xcodeproj/project.pbxproj
@@ -1071,10 +1071,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dnd.jon.Spellbook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "SWRevealViewController/Spellbook-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -1100,9 +1102,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dnd.jon.Spellbook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "SWRevealViewController/Spellbook-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Spellbook/AppDelegate.swift
+++ b/Spellbook/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // Disable rotation
-    var orientationLock = UIInterfaceOrientationMask.portrait
+    private let orientationLock = UIInterfaceOrientationMask.all
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         return self.orientationLock
     }

--- a/Spellbook/AppDelegate.swift
+++ b/Spellbook/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // Disable rotation
-    private let orientationLock = UIInterfaceOrientationMask.all
+    private let orientationLock = oniPad ? UIInterfaceOrientationMask.allButUpsideDown : UIInterfaceOrientationMask.portrait
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         return self.orientationLock
     }

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -579,7 +579,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                                 <subviews>
                                     <view opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xTV-VH-ZcY" userLabel="Content View">
-                                        <rect key="frame" x="8" y="0.0" width="414" height="240.33333333333334"/>
+                                        <rect key="frame" x="8" y="0.0" width="414" height="1333"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eMW-F5-hmt">
                                                 <rect key="frame" x="-62" y="21" width="363" height="85"/>
@@ -594,31 +594,31 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pc4-lp-KCl">
-                                                <rect key="frame" x="5" y="5" width="350.33333333333331" height="0.0"/>
+                                                <rect key="frame" x="5" y="5" width="0.0" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MBx-OV-kFQ">
-                                                <rect key="frame" x="5" y="7" width="350.33333333333331" height="0.0"/>
+                                                <rect key="frame" x="5" y="7" width="0.0" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LO2-Vv-zrI">
-                                                <rect key="frame" x="5" y="9" width="350.33333333333331" height="0.0"/>
+                                                <rect key="frame" x="5" y="9" width="0.0" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y43-NE-UnZ">
-                                                <rect key="frame" x="5" y="11" width="350.33333333333331" height="0.0"/>
+                                                <rect key="frame" x="5" y="11" width="0.0" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUT-AL-0TC">
-                                                <rect key="frame" x="5" y="13" width="350.33333333333331" height="0.0"/>
+                                                <rect key="frame" x="5" y="13" width="0.0" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
@@ -630,7 +630,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="31Y-hW-A43">
-                                                <rect key="frame" x="5" y="13" width="350.33333333333331" height="0.0"/>
+                                                <rect key="frame" x="5" y="13" width="0.0" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -648,7 +648,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BzG-dM-bz3">
-                                                <rect key="frame" x="5" y="19" width="350.33333333333331" height="0.0"/>
+                                                <rect key="frame" x="5" y="19" width="0.0" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
@@ -665,7 +665,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="z3p-02-z1G" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                <rect key="frame" x="355.33333333333331" y="1" width="53.666666666666686" height="53.666666666666664"/>
+                                                <rect key="frame" x="62" y="1" width="347" height="347"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="z3p-02-z1G" secondAttribute="height" multiplier="1:1" id="Dat-qE-U9v"/>
@@ -673,21 +673,21 @@
                                                 <state key="normal" image="star_empty.png"/>
                                             </button>
                                             <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="omB-O3-Bun" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                <rect key="frame" x="355.33333333333331" y="57.666666666666671" width="53.666666666666686" height="54"/>
+                                                <rect key="frame" x="-245" y="351" width="654" height="654"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="omB-O3-Bun" secondAttribute="height" multiplier="1:1" id="UZu-EA-Tiw"/>
                                                 </constraints>
                                                 <state key="normal" image="wand_empty.png"/>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f6W-mZ-pXE" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                <rect key="frame" x="355.33333333333331" y="114.66666666666667" width="53.666666666666686" height="53.666666666666671"/>
+                                                <rect key="frame" x="156" y="1008" width="253" height="253"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="f6W-mZ-pXE" secondAttribute="height" multiplier="1:1" id="6Ro-jl-CqV"/>
                                                 </constraints>
                                                 <state key="normal" image="book_empty.png"/>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qMf-rX-l1X" userLabel="Cast Button">
-                                                <rect key="frame" x="355.33333333333331" y="171.33333333333334" width="53.666666666666686" height="37"/>
+                                                <rect key="frame" x="260" y="1264" width="45" height="37"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <inset key="contentEdgeInsets" minX="5" minY="8" maxX="5" maxY="8"/>
@@ -709,54 +709,38 @@
                                         <constraints>
                                             <constraint firstItem="yfg-mz-Cj6" firstAttribute="top" secondItem="7Lk-KK-W3S" secondAttribute="bottom" constant="2" id="0Of-nJ-VSi"/>
                                             <constraint firstItem="hUT-AL-0TC" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="0eO-3A-5Oa"/>
-                                            <constraint firstItem="hUT-AL-0TC" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="0oq-mc-mS1"/>
-                                            <constraint firstItem="omB-O3-Bun" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.13" id="1cv-t8-cCY"/>
                                             <constraint firstItem="z3p-02-z1G" firstAttribute="trailing" secondItem="xTV-VH-ZcY" secondAttribute="trailing" constant="-5" id="1yH-CS-8tC"/>
                                             <constraint firstItem="f6W-mZ-pXE" firstAttribute="trailing" secondItem="xTV-VH-ZcY" secondAttribute="trailing" constant="-5" id="4sw-XT-v3G"/>
-                                            <constraint firstItem="z3p-02-z1G" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.13" id="6mi-9w-6p9"/>
                                             <constraint firstItem="MBx-OV-kFQ" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="71b-2R-D0o"/>
-                                            <constraint firstItem="qMf-rX-l1X" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.13" id="7h4-EI-z5J"/>
                                             <constraint firstItem="LO2-Vv-zrI" firstAttribute="top" secondItem="MBx-OV-kFQ" secondAttribute="bottom" constant="2" id="8xr-Zo-SgC"/>
                                             <constraint firstItem="qMf-rX-l1X" firstAttribute="top" relation="greaterThanOrEqual" secondItem="f6W-mZ-pXE" secondAttribute="bottom" constant="3" id="92H-bv-Tnh"/>
                                             <constraint firstItem="pc4-lp-KCl" firstAttribute="top" secondItem="RLp-JA-JL3" secondAttribute="bottom" constant="2" id="BSq-yV-P1q"/>
                                             <constraint firstItem="RLp-JA-JL3" firstAttribute="top" secondItem="eMW-F5-hmt" secondAttribute="bottom" constant="2" id="BbM-YP-TQ1"/>
-                                            <constraint firstItem="yfg-mz-Cj6" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="D9U-ca-A2c"/>
-                                            <constraint firstItem="AnF-D5-EEE" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="DDB-wx-n2b"/>
                                             <constraint firstItem="z3p-02-z1G" firstAttribute="top" secondItem="xTV-VH-ZcY" secondAttribute="top" constant="1" id="Dgr-kl-XiZ"/>
                                             <constraint firstItem="qMf-rX-l1X" firstAttribute="bottom" secondItem="0Wq-uU-OZd" secondAttribute="top" constant="-5" id="E0z-I2-duJ"/>
-                                            <constraint firstItem="RLp-JA-JL3" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="J1H-ZK-DEV"/>
                                             <constraint firstItem="BzG-dM-bz3" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="Jbh-xP-8Fs"/>
                                             <constraint firstItem="omB-O3-Bun" firstAttribute="trailing" secondItem="xTV-VH-ZcY" secondAttribute="trailing" constant="-5" id="KxE-mk-khv"/>
                                             <constraint firstItem="0Wq-uU-OZd" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="O6P-O1-v0v"/>
-                                            <constraint firstItem="MBx-OV-kFQ" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="Ova-Jp-kcC"/>
                                             <constraint firstItem="y43-NE-UnZ" firstAttribute="top" secondItem="LO2-Vv-zrI" secondAttribute="bottom" constant="2" id="PR7-IB-ZxF"/>
                                             <constraint firstItem="LO2-Vv-zrI" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="QvU-f0-NDz"/>
-                                            <constraint firstItem="LO2-Vv-zrI" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="RKN-Ze-zr9"/>
-                                            <constraint firstItem="pc4-lp-KCl" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="Rki-9x-FYZ"/>
                                             <constraint firstItem="RLp-JA-JL3" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="Sw6-2j-rXl"/>
                                             <constraint firstItem="BzG-dM-bz3" firstAttribute="top" secondItem="yfg-mz-Cj6" secondAttribute="bottom" constant="2" id="T0N-Qh-2vn"/>
                                             <constraint firstItem="AnF-D5-EEE" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="U39-6z-tlm"/>
                                             <constraint firstItem="AnF-D5-EEE" firstAttribute="top" secondItem="hUT-AL-0TC" secondAttribute="bottom" id="Uuh-X9-Mpb"/>
-                                            <constraint firstItem="BzG-dM-bz3" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="X8x-5M-YZP"/>
                                             <constraint firstItem="0Wq-uU-OZd" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="a8P-oo-PYZ"/>
                                             <constraint firstItem="7Lk-KK-W3S" firstAttribute="top" secondItem="31Y-hW-A43" secondAttribute="bottom" constant="2" id="aV6-xJ-nzf"/>
                                             <constraint firstItem="fny-iQ-Av2" firstAttribute="bottom" secondItem="xTV-VH-ZcY" secondAttribute="bottom" constant="-25" id="aru-dz-b2o"/>
                                             <constraint firstItem="yfg-mz-Cj6" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="bSt-tC-XnY"/>
-                                            <constraint firstItem="f6W-mZ-pXE" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.13" id="czw-2a-qkd"/>
-                                            <constraint firstItem="7Lk-KK-W3S" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="dHb-v6-bje"/>
                                             <constraint firstItem="7Lk-KK-W3S" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="dJ1-0n-Bjg"/>
-                                            <constraint firstItem="y43-NE-UnZ" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="dU9-Ux-a9b"/>
                                             <constraint firstItem="qMf-rX-l1X" firstAttribute="centerX" secondItem="f6W-mZ-pXE" secondAttribute="centerX" id="fdo-qZ-j2g"/>
                                             <constraint firstItem="31Y-hW-A43" firstAttribute="top" secondItem="AnF-D5-EEE" secondAttribute="bottom" id="frZ-29-dsB"/>
                                             <constraint firstItem="eMW-F5-hmt" firstAttribute="top" secondItem="xTV-VH-ZcY" secondAttribute="top" constant="1" id="gVE-Jr-UFL"/>
-                                            <constraint firstItem="31Y-hW-A43" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="hkg-yA-02R"/>
                                             <constraint firstItem="eMW-F5-hmt" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="iv9-YV-JUB"/>
                                             <constraint firstItem="0Wq-uU-OZd" firstAttribute="top" secondItem="BzG-dM-bz3" secondAttribute="bottom" constant="2" id="j65-b6-WWd"/>
                                             <constraint firstItem="fny-iQ-Av2" firstAttribute="top" secondItem="0Wq-uU-OZd" secondAttribute="bottom" constant="2" id="lil-Ia-17Z"/>
                                             <constraint firstItem="fny-iQ-Av2" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" constant="-10" id="mnb-Lr-2z8"/>
                                             <constraint firstItem="y43-NE-UnZ" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="oY4-IT-dpL"/>
                                             <constraint firstItem="pc4-lp-KCl" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="p4K-Fm-bqd"/>
-                                            <constraint firstItem="eMW-F5-hmt" firstAttribute="width" secondItem="xTV-VH-ZcY" secondAttribute="width" multiplier="0.87" constant="-10" id="qUE-hj-WTm"/>
                                             <constraint firstItem="fny-iQ-Av2" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="u1f-gE-P3N"/>
                                             <constraint firstItem="MBx-OV-kFQ" firstAttribute="top" secondItem="pc4-lp-KCl" secondAttribute="bottom" constant="2" id="w9P-GR-4XM"/>
                                             <constraint firstItem="31Y-hW-A43" firstAttribute="leading" secondItem="xTV-VH-ZcY" secondAttribute="leading" constant="5" id="xz6-qU-hA2"/>
@@ -1950,7 +1934,7 @@
                             <tableViewSection headerTitle="Filter Options" id="nkt-s2-SOP" userLabel="Filter Options">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="hzf-AI-tqn">
-                                        <rect key="frame" x="0.0" y="225.33333015441897" width="414" height="43.999999999999972"/>
+                                        <rect key="frame" x="0.0" y="225.33333015441895" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hzf-AI-tqn" id="14f-bY-mAc">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -2187,7 +2171,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="9m7-IC-edr" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="9m7-IC-edr" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Wy-Y7-3R4">
@@ -2245,7 +2229,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-JQ-hq6" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="vaj-JQ-hq6" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1na-Fe-aSv">
@@ -2335,7 +2319,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="9Av-vT-BMJ" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="9Av-vT-BMJ" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="kYh-hu-pH6">
@@ -2394,7 +2378,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="eJH-NJ-9aR" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="eJH-NJ-9aR" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="hCS-XO-M3z">
@@ -2481,7 +2465,7 @@
                                                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             </collectionViewFlowLayout>
                                                             <cells>
-                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="zjA-aV-cOq" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                                <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="zjA-aV-cOq" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                                     <rect key="frame" x="37" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                     <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="ld3-gq-3Nv">
@@ -2695,7 +2679,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="LR8-S2-cAX" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="LR8-S2-cAX" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eyw-BM-ZK5">
@@ -2817,7 +2801,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="ivf-rg-qoA" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="ivf-rg-qoA" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="1en-JT-doz">
@@ -2931,7 +2915,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="l2R-a5-9D9" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="l2R-a5-9D9" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="gfd-Qa-VSe">
@@ -3041,7 +3025,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="XWr-P7-zGZ" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="XWr-P7-zGZ" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="yeu-9c-2EZ">
@@ -3185,7 +3169,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="pZE-d0-NmF" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="pZE-d0-NmF" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="Rbu-PW-9Tz">
@@ -3324,7 +3308,7 @@
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     </collectionViewFlowLayout>
                                                     <cells>
-                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="Hpd-Dh-ert" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
+                                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="filterCell" translatesAutoresizingMaskIntoConstraints="NO" id="Hpd-Dh-ert" customClass="FilterCell" customModule="Spellbook" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="ze1-FN-cRj">

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -440,7 +440,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ur2-d0-T5w" userLabel="Favorite Button" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                    <rect key="frame" x="10" y="-12.666666666666666" width="34" height="34.333333333333336"/>
+                                                    <rect key="frame" x="277" y="-12.666666666666666" width="34" height="34.333333333333336"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="ur2-d0-T5w" secondAttribute="height" multiplier="1:1" id="1VY-jP-XGj"/>
@@ -448,7 +448,7 @@
                                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oBG-LC-kEi" userLabel="Known Button" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                    <rect key="frame" x="93" y="-12.666666666666666" width="34" height="34.333333333333336"/>
+                                                    <rect key="frame" x="360" y="-12.666666666666666" width="34" height="34.333333333333336"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="oBG-LC-kEi" secondAttribute="height" multiplier="1:1" id="uu8-fK-Dzt"/>
@@ -456,7 +456,7 @@
                                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6P0-N9-euK" userLabel="Prepared Button" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                    <rect key="frame" x="49" y="-12.666666666666666" width="34" height="34.333333333333336"/>
+                                                    <rect key="frame" x="316" y="-12.666666666666666" width="34" height="34.333333333333336"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="6P0-N9-euK" secondAttribute="height" multiplier="1:1" id="RkD-75-sF1"/>
@@ -469,7 +469,8 @@
                                             <constraints>
                                                 <constraint firstItem="Ber-Ky-GUN" firstAttribute="leading" secondItem="gQ9-or-WCo" secondAttribute="leading" id="3WD-0X-A6j"/>
                                                 <constraint firstItem="jt9-iC-lBj" firstAttribute="bottom" secondItem="Ber-Ky-GUN" secondAttribute="bottom" id="7iF-sc-UaW"/>
-                                                <constraint firstItem="ur2-d0-T5w" firstAttribute="leading" secondItem="gQ9-or-WCo" secondAttribute="trailing" constant="10" id="EUK-xt-eZV"/>
+                                                <constraint firstAttribute="trailing" secondItem="oBG-LC-kEi" secondAttribute="trailing" constant="10" id="B1X-pr-2yf"/>
+                                                <constraint firstItem="ur2-d0-T5w" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gQ9-or-WCo" secondAttribute="trailing" constant="10" id="EUK-xt-eZV"/>
                                                 <constraint firstItem="oBG-LC-kEi" firstAttribute="centerY" secondItem="P8j-J3-IBW" secondAttribute="centerY" id="LZT-JY-c5J"/>
                                                 <constraint firstAttribute="bottom" secondItem="Ber-Ky-GUN" secondAttribute="bottom" constant="3" id="N6U-1g-L0I"/>
                                                 <constraint firstItem="jt9-iC-lBj" firstAttribute="leading" secondItem="Ber-Ky-GUN" secondAttribute="trailing" constant="5" id="QFU-4y-mel"/>

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -762,7 +762,6 @@
                             <constraint firstItem="CkT-r0-Naw" firstAttribute="leading" secondItem="8Hn-aP-L0N" secondAttribute="leading" id="iZR-mz-GTP"/>
                             <constraint firstItem="ypa-xU-HWY" firstAttribute="centerX" secondItem="8Hn-aP-L0N" secondAttribute="centerX" id="rRm-To-2ea"/>
                             <constraint firstItem="ypa-xU-HWY" firstAttribute="centerY" secondItem="8Hn-aP-L0N" secondAttribute="centerY" id="tdU-Po-bfd"/>
-                            <constraint firstItem="ypa-xU-HWY" firstAttribute="width" secondItem="8Hn-aP-L0N" secondAttribute="width" id="yw2-Uh-h7j"/>
                             <constraint firstItem="xTV-VH-ZcY" firstAttribute="width" secondItem="772-30-LNw" secondAttribute="width" id="z0C-jF-WTD"/>
                         </constraints>
                     </view>
@@ -1662,102 +1661,125 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="xNj-3h-KOs">
+                            <imageView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="xNj-3h-KOs">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Spellbook" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wna-nj-ofa">
-                                <rect key="frame" x="5" y="93" width="404" height="59"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j8y-lz-uhw" customClass="UIScrollView">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tg0-0v-I7N" userLabel="Content View">
+                                        <rect key="frame" x="0.0" y="88" width="414" height="740"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Spellbook" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wna-nj-ofa">
+                                                <rect key="frame" x="5" y="4.9999999999999964" width="404" height="58.666666666666657"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" name="CloisterBlack-Light" family="Cloister Black" pointSize="50"/>
+                                                <color key="textColor" systemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <containerView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YnO-eH-2iK">
+                                                <rect key="frame" x="1" y="68.666666666666657" width="238" height="199.99999999999997"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="200" id="czw-3S-Hr6"/>
+                                                </constraints>
+                                                <connections>
+                                                    <segue destination="526-HG-Tzy" kind="embed" identifier="statusSegue" id="nsR-T5-eop"/>
+                                                </connections>
+                                            </containerView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xCE-VA-VJs">
+                                                <rect key="frame" x="5" y="273.66666666666669" width="0.0" height="0.0"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
+                                                <color key="textColor" systemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8BR-mp-g4U">
+                                                <rect key="frame" x="5" y="278.66666666666669" width="139" height="33"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <state key="normal" title="Change Character">
+                                                    <color key="titleColor" systemColor="darkTextColor"/>
+                                                </state>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qda-26-fCf" userLabel="Spell Slots Button">
+                                                <rect key="frame" x="86" y="48" width="67" height="31"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="Spell Slots">
+                                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wtt-Pc-x84" userLabel="Export Spell List Button">
+                                                <rect key="frame" x="46" y="46" width="147" height="35"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="Export Spell List">
+                                                    <color key="titleColor" name="DefaultFontColor"/>
+                                                </state>
+                                            </button>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Update Info" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-b5-jRQ">
+                                                <rect key="frame" x="67" y="52" width="106" height="23"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
+                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bgJ-32-A8i">
+                                                <rect key="frame" x="75" y="47" width="90" height="33"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <state key="normal" title="What's new">
+                                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="Qda-26-fCf" firstAttribute="leading" secondItem="Tg0-0v-I7N" secondAttribute="leading" constant="5" id="6rq-gE-nyf"/>
+                                            <constraint firstItem="wtt-Pc-x84" firstAttribute="top" secondItem="Qda-26-fCf" secondAttribute="bottom" constant="5" id="7au-82-Qfk"/>
+                                            <constraint firstItem="YnO-eH-2iK" firstAttribute="top" secondItem="wna-nj-ofa" secondAttribute="bottom" constant="5" id="DlS-eP-avs"/>
+                                            <constraint firstItem="wtt-Pc-x84" firstAttribute="leading" secondItem="Tg0-0v-I7N" secondAttribute="leading" constant="5" id="GSX-Zn-Gs1"/>
+                                            <constraint firstItem="eFO-b5-jRQ" firstAttribute="leading" secondItem="Tg0-0v-I7N" secondAttribute="leading" constant="5" id="HGP-pz-JUr"/>
+                                            <constraint firstItem="bgJ-32-A8i" firstAttribute="top" secondItem="eFO-b5-jRQ" secondAttribute="bottom" constant="5" id="Jpl-1D-aqG"/>
+                                            <constraint firstItem="xCE-VA-VJs" firstAttribute="top" secondItem="YnO-eH-2iK" secondAttribute="bottom" constant="5" id="L64-eP-caj"/>
+                                            <constraint firstItem="wna-nj-ofa" firstAttribute="leading" secondItem="Tg0-0v-I7N" secondAttribute="leading" constant="5" id="LLi-is-r22"/>
+                                            <constraint firstItem="wna-nj-ofa" firstAttribute="top" secondItem="Tg0-0v-I7N" secondAttribute="top" constant="5" id="Lq2-iO-1oO"/>
+                                            <constraint firstItem="xCE-VA-VJs" firstAttribute="leading" secondItem="Tg0-0v-I7N" secondAttribute="leading" constant="5" id="Pz2-Ej-8qm"/>
+                                            <constraint firstItem="eFO-b5-jRQ" firstAttribute="top" secondItem="wtt-Pc-x84" secondAttribute="bottom" constant="5" id="Q6u-5p-mbS"/>
+                                            <constraint firstItem="Qda-26-fCf" firstAttribute="top" secondItem="8BR-mp-g4U" secondAttribute="bottom" constant="5" id="TnW-ui-3Lp"/>
+                                            <constraint firstItem="8BR-mp-g4U" firstAttribute="top" secondItem="xCE-VA-VJs" secondAttribute="bottom" constant="5" id="Xxb-5C-6JX"/>
+                                            <constraint firstItem="bgJ-32-A8i" firstAttribute="leading" secondItem="Tg0-0v-I7N" secondAttribute="leading" constant="5" id="aKA-W3-12q"/>
+                                            <constraint firstItem="YnO-eH-2iK" firstAttribute="leading" secondItem="Tg0-0v-I7N" secondAttribute="leading" constant="5" id="d45-qH-u2a"/>
+                                            <constraint firstAttribute="trailing" secondItem="wna-nj-ofa" secondAttribute="trailing" constant="5" id="sbn-db-q2E"/>
+                                            <constraint firstItem="8BR-mp-g4U" firstAttribute="leading" secondItem="Tg0-0v-I7N" secondAttribute="leading" constant="5" id="xNo-vn-i9L"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <fontDescription key="fontDescription" name="CloisterBlack-Light" family="Cloister Black" pointSize="50"/>
-                                <color key="textColor" systemColor="darkTextColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <containerView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YnO-eH-2iK">
-                                <rect key="frame" x="86" y="157" width="238" height="200"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="200" id="czw-3S-Hr6"/>
-                                </constraints>
-                                <connections>
-                                    <segue destination="526-HG-Tzy" kind="embed" identifier="statusSegue" id="nsR-T5-eop"/>
-                                </connections>
-                            </containerView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xCE-VA-VJs">
-                                <rect key="frame" x="186" y="437" width="0.0" height="0.0"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
-                                <color key="textColor" systemColor="darkTextColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Update Info" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-b5-jRQ">
-                                <rect key="frame" x="186" y="437" width="106" height="23"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
-                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bgJ-32-A8i">
-                                <rect key="frame" x="163" y="432" width="90" height="33"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <state key="normal" title="What's new">
-                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8BR-mp-g4U">
-                                <rect key="frame" x="-18" y="868" width="140" height="33"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <state key="normal" title="Change Character">
-                                    <color key="titleColor" systemColor="darkTextColor"/>
-                                </state>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wtt-Pc-x84" userLabel="Export Spell List Button">
-                                <rect key="frame" x="133" y="430" width="147" height="35"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" title="Export Spell List">
-                                    <color key="titleColor" name="DefaultFontColor"/>
-                                </state>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qda-26-fCf" userLabel="Spell Slots Button">
-                                <rect key="frame" x="173" y="432" width="67" height="31"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" title="Spell Slots">
-                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                            </button>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="baK-Me-bgK"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="bgJ-32-A8i" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="0ps-Fu-2Ig"/>
-                            <constraint firstItem="wtt-Pc-x84" firstAttribute="top" secondItem="Qda-26-fCf" secondAttribute="bottom" constant="5" id="6v6-Ym-C3f"/>
-                            <constraint firstItem="wtt-Pc-x84" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="Bnc-TP-vfr"/>
-                            <constraint firstItem="YnO-eH-2iK" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="CMC-iO-Jot"/>
-                            <constraint firstItem="8BR-mp-g4U" firstAttribute="top" secondItem="xCE-VA-VJs" secondAttribute="bottom" constant="5" id="FY4-Ty-297"/>
-                            <constraint firstItem="xNj-3h-KOs" firstAttribute="top" secondItem="FqS-5k-Jrh" secondAttribute="top" id="RfL-1h-twC"/>
-                            <constraint firstItem="xCE-VA-VJs" firstAttribute="top" secondItem="YnO-eH-2iK" secondAttribute="bottom" constant="5" id="UaW-sZ-Z4p"/>
-                            <constraint firstItem="wtt-Pc-x84" firstAttribute="top" secondItem="Qda-26-fCf" secondAttribute="bottom" constant="5" id="Udd-QM-fkb"/>
-                            <constraint firstItem="wna-nj-ofa" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="f6D-sL-mN2"/>
-                            <constraint firstItem="xNj-3h-KOs" firstAttribute="leading" secondItem="FqS-5k-Jrh" secondAttribute="leading" id="fvn-R2-748"/>
-                            <constraint firstAttribute="bottom" secondItem="xNj-3h-KOs" secondAttribute="bottom" id="g48-Uk-Fv6"/>
-                            <constraint firstItem="Qda-26-fCf" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="iQj-9D-EMf"/>
-                            <constraint firstItem="eFO-b5-jRQ" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="jcO-7o-o89"/>
-                            <constraint firstItem="Qda-26-fCf" firstAttribute="top" secondItem="8BR-mp-g4U" secondAttribute="bottom" constant="5" id="lYP-EJ-CqG"/>
-                            <constraint firstItem="YnO-eH-2iK" firstAttribute="top" secondItem="wna-nj-ofa" secondAttribute="bottom" constant="5" id="mfX-Y6-Awh"/>
-                            <constraint firstItem="xCE-VA-VJs" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="n62-tC-gw2"/>
-                            <constraint firstItem="8BR-mp-g4U" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="nM3-A5-eWe"/>
-                            <constraint firstItem="bgJ-32-A8i" firstAttribute="top" secondItem="eFO-b5-jRQ" secondAttribute="bottom" constant="5" id="r83-Yg-aXp"/>
-                            <constraint firstItem="baK-Me-bgK" firstAttribute="trailing" secondItem="wna-nj-ofa" secondAttribute="trailing" constant="5" id="txh-iH-UeJ"/>
-                            <constraint firstItem="xNj-3h-KOs" firstAttribute="trailing" secondItem="FqS-5k-Jrh" secondAttribute="trailing" id="uRY-f0-qD6"/>
-                            <constraint firstItem="wna-nj-ofa" firstAttribute="top" secondItem="baK-Me-bgK" secondAttribute="top" constant="5" id="ubh-wW-z6j"/>
-                            <constraint firstItem="eFO-b5-jRQ" firstAttribute="top" secondItem="wtt-Pc-x84" secondAttribute="bottom" constant="5" id="yhp-dI-JEg"/>
+                            <constraint firstItem="xNj-3h-KOs" firstAttribute="width" secondItem="FqS-5k-Jrh" secondAttribute="width" id="0Kd-ug-ffN"/>
+                            <constraint firstItem="Tg0-0v-I7N" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" id="2NQ-E5-1fG"/>
+                            <constraint firstItem="xNj-3h-KOs" firstAttribute="centerX" secondItem="FqS-5k-Jrh" secondAttribute="centerX" id="NQp-RN-ThX"/>
+                            <constraint firstItem="xNj-3h-KOs" firstAttribute="height" secondItem="FqS-5k-Jrh" secondAttribute="height" id="TML-1P-o8K"/>
+                            <constraint firstItem="xNj-3h-KOs" firstAttribute="centerY" secondItem="FqS-5k-Jrh" secondAttribute="centerY" id="V9x-sj-bVj"/>
+                            <constraint firstItem="j8y-lz-uhw" firstAttribute="top" secondItem="FqS-5k-Jrh" secondAttribute="top" id="a5f-zd-YdI"/>
+                            <constraint firstItem="Tg0-0v-I7N" firstAttribute="top" secondItem="baK-Me-bgK" secondAttribute="top" id="bEU-Pn-BMk"/>
+                            <constraint firstAttribute="bottom" secondItem="j8y-lz-uhw" secondAttribute="bottom" id="e4O-Ja-kc7"/>
+                            <constraint firstItem="j8y-lz-uhw" firstAttribute="leading" secondItem="FqS-5k-Jrh" secondAttribute="leading" id="gNE-pH-3bC"/>
+                            <constraint firstItem="Tg0-0v-I7N" firstAttribute="width" secondItem="baK-Me-bgK" secondAttribute="width" id="geg-Af-KW0"/>
+                            <constraint firstAttribute="trailing" secondItem="j8y-lz-uhw" secondAttribute="trailing" id="j4w-Qj-BmE"/>
+                            <constraint firstItem="Tg0-0v-I7N" firstAttribute="height" secondItem="baK-Me-bgK" secondAttribute="height" id="yZx-fB-5Ni"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="backgroundView" destination="xNj-3h-KOs" id="ZAt-GZ-cVZ"/>
                         <outlet property="characterLabel" destination="xCE-VA-VJs" id="CA9-Ik-AHs"/>
+                        <outlet property="contentView" destination="Tg0-0v-I7N" id="MNA-Mw-bVX"/>
                         <outlet property="exportSpellListButton" destination="wtt-Pc-x84" id="TLd-C1-CJF"/>
+                        <outlet property="scrollView" destination="j8y-lz-uhw" id="2cq-zt-JFd"/>
                         <outlet property="selectionButton" destination="8BR-mp-g4U" id="eZ4-yL-ucW"/>
                         <outlet property="sideMenuHeader" destination="wna-nj-ofa" id="xMA-ns-dai"/>
                         <outlet property="spellSlotsButton" destination="Qda-26-fCf" id="QrG-R1-yGZ"/>
@@ -1775,7 +1797,7 @@
             <objects>
                 <viewController id="526-HG-Tzy" customClass="StatusFilterController" customModule="Spellbook" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Jzb-0h-mv9" customClass="UITableView">
-                        <rect key="frame" x="0.0" y="0.0" width="238" height="128"/>
+                        <rect key="frame" x="0.0" y="0.0" width="238" height="200"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="statusMenuCell" translatesAutoresizingMaskIntoConstraints="NO" id="hC5-Lg-NpH" customClass="SideMenuCell" customModule="Spellbook" customModuleProvider="target">

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -421,7 +421,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gQ9-or-WCo" userLabel="Name Label">
-                                                    <rect key="frame" x="0.0" y="5" width="272.66666666666669" height="0.0"/>
+                                                    <rect key="frame" x="0.0" y="5" width="0.0" height="0.0"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -440,7 +440,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ur2-d0-T5w" userLabel="Favorite Button" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                    <rect key="frame" x="282.66666666666669" y="-15.666666666666666" width="40.666666666666686" height="40.333333333333336"/>
+                                                    <rect key="frame" x="10" y="-12.666666666666666" width="34" height="34.333333333333336"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="ur2-d0-T5w" secondAttribute="height" multiplier="1:1" id="1VY-jP-XGj"/>
@@ -448,7 +448,7 @@
                                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oBG-LC-kEi" userLabel="Known Button" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                    <rect key="frame" x="365.66666666666669" y="-15.666666666666666" width="40.333333333333314" height="40.333333333333336"/>
+                                                    <rect key="frame" x="93" y="-12.666666666666666" width="34" height="34.333333333333336"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="oBG-LC-kEi" secondAttribute="height" multiplier="1:1" id="uu8-fK-Dzt"/>
@@ -456,7 +456,7 @@
                                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6P0-N9-euK" userLabel="Prepared Button" customClass="ToggleButton" customModule="Spellbook" customModuleProvider="target">
-                                                    <rect key="frame" x="324.33333333333331" y="-15.666666666666666" width="40.333333333333314" height="40.333333333333336"/>
+                                                    <rect key="frame" x="49" y="-12.666666666666666" width="34" height="34.333333333333336"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="6P0-N9-euK" secondAttribute="height" multiplier="1:1" id="RkD-75-sF1"/>
@@ -468,20 +468,16 @@
                                             <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstItem="Ber-Ky-GUN" firstAttribute="leading" secondItem="gQ9-or-WCo" secondAttribute="leading" id="3WD-0X-A6j"/>
-                                                <constraint firstItem="gQ9-or-WCo" firstAttribute="trailing" secondItem="P8j-J3-IBW" secondAttribute="trailing" multiplier="0.7" constant="-10" id="5Pl-OY-VRl"/>
                                                 <constraint firstItem="jt9-iC-lBj" firstAttribute="bottom" secondItem="Ber-Ky-GUN" secondAttribute="bottom" id="7iF-sc-UaW"/>
                                                 <constraint firstItem="ur2-d0-T5w" firstAttribute="leading" secondItem="gQ9-or-WCo" secondAttribute="trailing" constant="10" id="EUK-xt-eZV"/>
                                                 <constraint firstItem="oBG-LC-kEi" firstAttribute="centerY" secondItem="P8j-J3-IBW" secondAttribute="centerY" id="LZT-JY-c5J"/>
                                                 <constraint firstAttribute="bottom" secondItem="Ber-Ky-GUN" secondAttribute="bottom" constant="3" id="N6U-1g-L0I"/>
                                                 <constraint firstItem="jt9-iC-lBj" firstAttribute="leading" secondItem="Ber-Ky-GUN" secondAttribute="trailing" constant="5" id="QFU-4y-mel"/>
-                                                <constraint firstItem="oBG-LC-kEi" firstAttribute="leading" secondItem="6P0-N9-euK" secondAttribute="trailing" constant="1" id="Rnm-hg-go7"/>
-                                                <constraint firstItem="ur2-d0-T5w" firstAttribute="width" secondItem="P8j-J3-IBW" secondAttribute="width" multiplier="0.1" id="XOv-2t-OMN"/>
-                                                <constraint firstItem="6P0-N9-euK" firstAttribute="width" secondItem="P8j-J3-IBW" secondAttribute="width" multiplier="0.1" id="a7M-tU-Drn"/>
+                                                <constraint firstItem="oBG-LC-kEi" firstAttribute="leading" secondItem="6P0-N9-euK" secondAttribute="trailing" constant="10" id="Rnm-hg-go7"/>
                                                 <constraint firstItem="gQ9-or-WCo" firstAttribute="leading" secondItem="P8j-J3-IBW" secondAttribute="leading" id="czf-GW-gVf"/>
-                                                <constraint firstItem="oBG-LC-kEi" firstAttribute="width" secondItem="P8j-J3-IBW" secondAttribute="width" multiplier="0.1" id="fAv-KI-0Bf"/>
                                                 <constraint firstItem="gQ9-or-WCo" firstAttribute="top" secondItem="P8j-J3-IBW" secondAttribute="top" constant="5" id="jWz-15-oLW"/>
                                                 <constraint firstItem="ur2-d0-T5w" firstAttribute="centerY" secondItem="P8j-J3-IBW" secondAttribute="centerY" id="plC-sb-2f9"/>
-                                                <constraint firstItem="6P0-N9-euK" firstAttribute="leading" secondItem="ur2-d0-T5w" secondAttribute="trailing" constant="1" id="rDZ-NY-pVY"/>
+                                                <constraint firstItem="6P0-N9-euK" firstAttribute="leading" secondItem="ur2-d0-T5w" secondAttribute="trailing" constant="5" id="rDZ-NY-pVY"/>
                                                 <constraint firstItem="6P0-N9-euK" firstAttribute="centerY" secondItem="P8j-J3-IBW" secondAttribute="centerY" id="vYQ-zR-NDe"/>
                                                 <constraint firstItem="Ber-Ky-GUN" firstAttribute="top" secondItem="gQ9-or-WCo" secondAttribute="bottom" constant="1" id="yid-9p-Vqr"/>
                                             </constraints>

--- a/Spellbook/Base.lproj/Main.storyboard
+++ b/Spellbook/Base.lproj/Main.storyboard
@@ -1662,70 +1662,64 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="xNj-3h-KOs">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BookBackground.jpeg" translatesAutoresizingMaskIntoConstraints="NO" id="xNj-3h-KOs">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Spellbook" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wna-nj-ofa">
-                                <rect key="frame" x="186" y="437" width="192" height="59"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Spellbook" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wna-nj-ofa">
+                                <rect key="frame" x="5" y="93" width="404" height="59"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" name="CloisterBlack-Light" family="Cloister Black" pointSize="50"/>
                                 <color key="textColor" systemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <containerView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YnO-eH-2iK">
-                                <rect key="frame" x="86" y="380" width="238" height="128"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                            <containerView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YnO-eH-2iK">
+                                <rect key="frame" x="86" y="157" width="238" height="200"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="200" id="czw-3S-Hr6"/>
+                                </constraints>
                                 <connections>
                                     <segue destination="526-HG-Tzy" kind="embed" identifier="statusSegue" id="nsR-T5-eop"/>
                                 </connections>
                             </containerView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xCE-VA-VJs">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xCE-VA-VJs">
                                 <rect key="frame" x="186" y="437" width="0.0" height="0.0"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
                                 <color key="textColor" systemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Update Info" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-b5-jRQ">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Update Info" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-b5-jRQ">
                                 <rect key="frame" x="186" y="437" width="106" height="23"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bgJ-32-A8i">
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bgJ-32-A8i">
                                 <rect key="frame" x="163" y="432" width="90" height="33"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <state key="normal" title="What's new">
                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8BR-mp-g4U">
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8BR-mp-g4U">
                                 <rect key="frame" x="-18" y="868" width="140" height="33"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <state key="normal" title="Change Character">
                                     <color key="titleColor" systemColor="darkTextColor"/>
                                 </state>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wtt-Pc-x84" userLabel="Export Spell List Button">
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wtt-Pc-x84" userLabel="Export Spell List Button">
                                 <rect key="frame" x="133" y="430" width="147" height="35"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Export Spell List">
                                     <color key="titleColor" name="DefaultFontColor"/>
                                 </state>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qda-26-fCf" userLabel="Spell Slots Button">
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qda-26-fCf" userLabel="Spell Slots Button">
                                 <rect key="frame" x="173" y="432" width="67" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Spell Slots">
@@ -1735,6 +1729,30 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="baK-Me-bgK"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="bgJ-32-A8i" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="0ps-Fu-2Ig"/>
+                            <constraint firstItem="wtt-Pc-x84" firstAttribute="top" secondItem="Qda-26-fCf" secondAttribute="bottom" constant="5" id="6v6-Ym-C3f"/>
+                            <constraint firstItem="wtt-Pc-x84" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="Bnc-TP-vfr"/>
+                            <constraint firstItem="YnO-eH-2iK" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="CMC-iO-Jot"/>
+                            <constraint firstItem="8BR-mp-g4U" firstAttribute="top" secondItem="xCE-VA-VJs" secondAttribute="bottom" constant="5" id="FY4-Ty-297"/>
+                            <constraint firstItem="xNj-3h-KOs" firstAttribute="top" secondItem="FqS-5k-Jrh" secondAttribute="top" id="RfL-1h-twC"/>
+                            <constraint firstItem="xCE-VA-VJs" firstAttribute="top" secondItem="YnO-eH-2iK" secondAttribute="bottom" constant="5" id="UaW-sZ-Z4p"/>
+                            <constraint firstItem="wtt-Pc-x84" firstAttribute="top" secondItem="Qda-26-fCf" secondAttribute="bottom" constant="5" id="Udd-QM-fkb"/>
+                            <constraint firstItem="wna-nj-ofa" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="f6D-sL-mN2"/>
+                            <constraint firstItem="xNj-3h-KOs" firstAttribute="leading" secondItem="FqS-5k-Jrh" secondAttribute="leading" id="fvn-R2-748"/>
+                            <constraint firstAttribute="bottom" secondItem="xNj-3h-KOs" secondAttribute="bottom" id="g48-Uk-Fv6"/>
+                            <constraint firstItem="Qda-26-fCf" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="iQj-9D-EMf"/>
+                            <constraint firstItem="eFO-b5-jRQ" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="jcO-7o-o89"/>
+                            <constraint firstItem="Qda-26-fCf" firstAttribute="top" secondItem="8BR-mp-g4U" secondAttribute="bottom" constant="5" id="lYP-EJ-CqG"/>
+                            <constraint firstItem="YnO-eH-2iK" firstAttribute="top" secondItem="wna-nj-ofa" secondAttribute="bottom" constant="5" id="mfX-Y6-Awh"/>
+                            <constraint firstItem="xCE-VA-VJs" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="n62-tC-gw2"/>
+                            <constraint firstItem="8BR-mp-g4U" firstAttribute="leading" secondItem="baK-Me-bgK" secondAttribute="leading" constant="5" id="nM3-A5-eWe"/>
+                            <constraint firstItem="bgJ-32-A8i" firstAttribute="top" secondItem="eFO-b5-jRQ" secondAttribute="bottom" constant="5" id="r83-Yg-aXp"/>
+                            <constraint firstItem="baK-Me-bgK" firstAttribute="trailing" secondItem="wna-nj-ofa" secondAttribute="trailing" constant="5" id="txh-iH-UeJ"/>
+                            <constraint firstItem="xNj-3h-KOs" firstAttribute="trailing" secondItem="FqS-5k-Jrh" secondAttribute="trailing" id="uRY-f0-qD6"/>
+                            <constraint firstItem="wna-nj-ofa" firstAttribute="top" secondItem="baK-Me-bgK" secondAttribute="top" constant="5" id="ubh-wW-z6j"/>
+                            <constraint firstItem="eFO-b5-jRQ" firstAttribute="top" secondItem="wtt-Pc-x84" secondAttribute="bottom" constant="5" id="yhp-dI-JEg"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="backgroundView" destination="xNj-3h-KOs" id="ZAt-GZ-cVZ"/>

--- a/Spellbook/SideMenuController.swift
+++ b/Spellbook/SideMenuController.swift
@@ -20,6 +20,8 @@ class SideMenuController: UIViewController, UIPopoverPresentationControllerDeleg
     @IBOutlet weak var updateInfoLabel: UILabel!
     @IBOutlet weak var whatsNewButton: UIButton!
     @IBOutlet weak var spellSlotsButton: UIButton!
+    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet weak var contentView: UIView!
     
     var statusController: StatusFilterController?
     
@@ -62,6 +64,11 @@ class SideMenuController: UIViewController, UIPopoverPresentationControllerDeleg
         viewWidth = viewRect.size.width
         
         characterLabel.textColor = defaultFontColor
+        
+        selectionButton.addTarget(self, action: #selector(selectionButtonPressed), for: UIControl.Event.touchUpInside)
+        exportSpellListButton.addTarget(self, action: #selector(exportSpellListButtonPressed), for: UIControl.Event.touchUpInside)
+        whatsNewButton.addTarget(self, action: #selector(updateInfoButtonPressed), for: UIControl.Event.touchUpInside)
+        spellSlotsButton.addTarget(self, action: #selector(spellSlotsButtonPressed), for: UIControl.Event.touchUpInside)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -70,7 +77,7 @@ class SideMenuController: UIViewController, UIPopoverPresentationControllerDeleg
             $0.select { $0.profile?.name }
         }
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         
         // Set the character label
@@ -79,7 +86,24 @@ class SideMenuController: UIViewController, UIPopoverPresentationControllerDeleg
             characterLabel.text = "Character: " + name!
         }
     }
-    
+
+    func setScrollViewSize() {
+        if let content = contentView, let scroll = scrollView {
+            // The content size of the scroll view is equal to the content view's size
+            scroll.contentSize = content.frame.size
+            
+        }
+    }
+
+    override func viewWillTransition(to size: CGSize,
+                                     with coordinator: UIViewControllerTransitionCoordinator) {
+        setScrollViewSize()
+    }
+
+    override func viewDidLayoutSubviews() {
+        setScrollViewSize()
+    }
+
     // Connecting to the child controllers
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "statusSegue" {
@@ -96,11 +120,11 @@ class SideMenuController: UIViewController, UIPopoverPresentationControllerDeleg
 //
 //        }
     }
-    
+
     func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
         return UIModalPresentationStyle.none
     }
-    
+
     @objc func selectionButtonPressed() {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let controller = storyboard.instantiateViewController(withIdentifier: "characterSelection") as! CharacterSelectionController

--- a/Spellbook/SideMenuController.swift
+++ b/Spellbook/SideMenuController.swift
@@ -61,69 +61,7 @@ class SideMenuController: UIViewController, UIPopoverPresentationControllerDeleg
         viewHeight = viewRect.size.height
         viewWidth = viewRect.size.width
         
-        // Set the dimensions for the background image
-        // No padding necessary for this
-        backgroundView.frame = CGRect(x: 0, y: -backgroundOffset, width: viewWidth, height: viewHeight + backgroundOffset)
-        
-        //let headerHeight = CGFloat(0.1 * viewHeight)
-        //let statusFilterHeight = CGFloat(0.3 * viewHeight)
-        let headerHeight = CGFloat(57)
-        let statusFilterHeight = CGFloat(171)
-        let characterLabelHeight = CGFloat(20)
-        let exportSpellListLabelHeight = CGFloat(20)
-        let selectionButtonHeight = CGFloat(20)
-        let spellSlotsButtonHeight = CGFloat(20)
-        let belowFilterPadding = min(max(0.05 * SizeUtils.screenHeight, 25), 40)
-        let belowCharacterLabelPadding = CGFloat(14)
-        let belowExportSpellListLabelPadding = CGFloat(14)
-        let belowSelectionButtonPadding = CGFloat(20)
-        let belowSpellSlotsButtonPadding = CGFloat(23)
-        let notchTopPadding = CGFloat(35)
-        let updateInfoLabelHeight = CGFloat(20)
-        let belowUpdateInfoLabelPadding = CGFloat(14)
-        let whatsNewButtonHeight = CGFloat(20)
-        
-        // Does the device have a notch or not?
-        let hasNotch = UIDevice.current.hasNotch
-        
-        // Set up the view positioning
-        var currentY = CGFloat(topPadding)
-        if hasNotch {
-            currentY += notchTopPadding
-        }
-        sideMenuHeader.frame = CGRect(x: leftPadding, y: currentY, width: viewWidth, height: headerHeight)
-        
-        currentY += (headerHeight + tablePadding)
-        statusFilterView.frame = CGRect(x: leftPadding, y: currentY, width: viewWidth - leftPadding, height: statusFilterHeight + belowFilterPadding)
-        
-        currentY += (statusFilterHeight + belowFilterPadding)
-        characterLabel.frame = CGRect(x: leftPadding, y: currentY, width: viewWidth - leftPadding, height: characterLabelHeight)
-        
-        currentY += characterLabelHeight + belowCharacterLabelPadding
-        selectionButton.frame = CGRect(x: leftPadding, y: currentY, width: viewWidth - leftPadding, height: selectionButtonHeight)
-        
-        currentY += exportSpellListLabelHeight + belowExportSpellListLabelPadding
-        exportSpellListButton.frame = CGRect(x: leftPadding, y: currentY, width: viewWidth - leftPadding, height: exportSpellListLabelHeight)
-        
-        currentY += spellSlotsButtonHeight + belowSelectionButtonPadding
-        spellSlotsButton.frame = CGRect(x: leftPadding, y: currentY, width: viewWidth - leftPadding, height: spellSlotsButtonHeight)
-        
-        currentY += selectionButtonHeight + belowSpellSlotsButtonPadding
-        updateInfoLabel.frame = CGRect(x: leftPadding, y: currentY, width: viewWidth - leftPadding, height: updateInfoLabelHeight)
-        
-        currentY += updateInfoLabelHeight + belowUpdateInfoLabelPadding
-        whatsNewButton.frame = CGRect(x: leftPadding, y: currentY, width: viewWidth - leftPadding, height: whatsNewButtonHeight)
-        
-        selectionButton.addTarget(self, action: #selector(selectionButtonPressed), for: UIControl.Event.touchUpInside)
-        
-        exportSpellListButton.addTarget(self, action: #selector(exportSpellListButtonPressed), for: UIControl.Event.touchUpInside)
-        
-        whatsNewButton.addTarget(self, action: #selector(updateInfoButtonPressed), for: UIControl.Event.touchUpInside)
-        
-        spellSlotsButton.addTarget(self, action: #selector(spellSlotsButtonPressed), for: UIControl.Event.touchUpInside)
-        
         characterLabel.textColor = defaultFontColor
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -166,7 +104,6 @@ class SideMenuController: UIViewController, UIPopoverPresentationControllerDeleg
     @objc func selectionButtonPressed() {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let controller = storyboard.instantiateViewController(withIdentifier: "characterSelection") as! CharacterSelectionController
-        
         
         let popupHeight = 0.5 * SizeUtils.screenHeight
         let popupWidth = 0.75 * SizeUtils.screenWidth

--- a/Spellbook/SpellTableViewController.swift
+++ b/Spellbook/SpellTableViewController.swift
@@ -39,7 +39,8 @@ class SpellTableViewController: UITableViewController {
     // The button images
     // It's too costly to do the re-rendering every time, so we just do it once
     static let buttonFraction = CGFloat(0.09)
-    static let imageWidth = SpellTableViewController.buttonFraction * ViewController.usableWidth
+    static let usableWidth = UIScreen.main.bounds.width - 10
+    static let imageWidth = SpellTableViewController.buttonFraction * SpellTableViewController.usableWidth
     static let imageHeight = SpellTableViewController.imageWidth
     static let starEmpty = UIImage(named: "star_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: SpellTableViewController.imageWidth, height: SpellTableViewController.imageHeight)
     static let starFilled = UIImage(named: "star_filled.png")?.withRenderingMode(.alwaysOriginal).resized(width: SpellTableViewController.imageWidth, height: SpellTableViewController.imageHeight)

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -15,7 +15,7 @@ class SpellWindowController: UIViewController {
     
     // How much of the horizontal width goes to the name label
     // The rest is for the favoriting button
-    static let majorWidthFraction = oniPad ? CGFloat(0.94) : CGFloat(0.87)
+    static let majorWidthFraction = oniPad ? CGFloat(0.94) : CGFloat(0.86)
     static let minorWidthFraction = 1 - SpellWindowController.majorWidthFraction
     static let halfGapWidth = CGFloat(10)
     static let imageWidth = UIScreen.main.bounds.width * SpellWindowController.minorWidthFraction
@@ -93,13 +93,22 @@ class SpellWindowController: UIViewController {
         super.init(coder: coder)
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
+    private var swipeRightHandler: UISwipeGestureRecognizer? = nil
+    private func setupSwipeRightHandler() {
+        if let handler = self.swipeRightHandler {
+            self.view.removeGestureRecognizer(handler)
+        }
         // We close the window on a swipe to the right
         let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(respondToSwipeGesture))
         swipeRight.direction = UISwipeGestureRecognizer.Direction.right
         self.view.addGestureRecognizer(swipeRight)
+        self.swipeRightHandler = swipeRight
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupSwipeRightHandler()
         
         // Set the button images
         favoriteButton.setTrueImage(image: SpellWindowController.isFavoriteImage!)
@@ -171,14 +180,24 @@ class SpellWindowController: UIViewController {
         labels.forEach { $0!.textColor = defaultFontColor }
         
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        
+        // Set the content view to fill the screen
+        contentView.frame = UIScreen.main.bounds
         
         // The content size of the scroll view is equal to the content view's size
         scrollView.contentSize = contentView.frame.size
     }
     
+    override func viewWillTransition(to size: CGSize,
+                                     with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        scrollView.contentSize = contentView.frame.size
+        setupSwipeRightHandler()
+    }
+
     @objc func respondToSwipeGesture(gesture: UIGestureRecognizer) {
         if let swipeGesture = gesture as? UISwipeGestureRecognizer {
             switch swipeGesture.direction {

--- a/Spellbook/SpellWindowController.swift
+++ b/Spellbook/SpellWindowController.swift
@@ -15,10 +15,11 @@ class SpellWindowController: UIViewController {
     
     // How much of the horizontal width goes to the name label
     // The rest is for the favoriting button
-    static let nameLabelFraction = CGFloat(0.87)
-    static let buttonFraction = 1 - SpellWindowController.nameLabelFraction
-    static let imageWidth = UIScreen.main.bounds.width * SpellWindowController.buttonFraction
-    static let imageHeight = UIScreen.main.bounds.width * SpellWindowController.buttonFraction
+    static let majorWidthFraction = oniPad ? CGFloat(0.94) : CGFloat(0.87)
+    static let minorWidthFraction = 1 - SpellWindowController.majorWidthFraction
+    static let halfGapWidth = CGFloat(10)
+    static let imageWidth = UIScreen.main.bounds.width * SpellWindowController.minorWidthFraction
+    static let imageHeight = UIScreen.main.bounds.width * SpellWindowController.minorWidthFraction
     
     // Font sizes
     static let nameSize = CGFloat(30)
@@ -130,10 +131,44 @@ class SpellWindowController: UIViewController {
         // Set the content view to fill the screen
         contentView.frame = UIScreen.main.bounds
         
+        let minorWidthViews = [
+            favoriteButton,
+            preparedButton,
+            knownButton,
+            castButton
+        ]
+        let majorWidthViews = [
+            locationLabel,
+            concentrationLabel,
+            castingTimeLabel,
+            rangeLabel,
+            royaltyLabel,
+            componentsLabel,
+            expandedClassesLabel,
+            spellNameLabel,
+            schoolLevelLabel,
+            durationLabel,
+            materialsLabel,
+            classesLabel,
+        ]
+
+        let width = contentView.frame.width
+
+        NSLayoutConstraint.activate(minorWidthViews.compactMap({ view in
+            return view?.widthAnchor.constraint(equalToConstant: SpellWindowController.minorWidthFraction * width - SpellWindowController.halfGapWidth)
+        }))
+        NSLayoutConstraint.activate(majorWidthViews.compactMap({ view in
+            return view?.widthAnchor.constraint(equalToConstant: SpellWindowController.majorWidthFraction * width - SpellWindowController.halfGapWidth)
+        }))
+        NSLayoutConstraint.activate([
+            favoriteButton.widthAnchor.constraint(equalToConstant: SpellWindowController.minorWidthFraction * width),
+            preparedButton.widthAnchor.constraint(equalToConstant: SpellWindowController.minorWidthFraction * width),
+            knownButton.widthAnchor.constraint(equalToConstant: SpellWindowController.minorWidthFraction * width),
+        ])
+
         // Set the label fonts
         let labels = [ spellNameLabel, schoolLevelLabel, locationLabel, concentrationLabel, castingTimeLabel, rangeLabel, componentsLabel, materialsLabel, durationLabel, classesLabel, expandedClassesLabel, descriptionLabel, higherLevelLabel ]
         labels.forEach { $0!.textColor = defaultFontColor }
-        
         
     }
     

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -269,7 +269,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     // This function sets the sizes of the top-level container views
     func setContainerDimensions(screenWidth: CGFloat, screenHeight: CGFloat) {
         
-        self.buttonFraction = oniPad ? CGFloat(0.04) : CGFloat(0.09)
+        self.buttonFraction = oniPad ? CGFloat(0.04) : CGFloat(0.08)
 
         // Get the padding sizes
         let leftPadding = max(min(leftPaddingFraction * screenWidth, maxHorizPadding), minHorizPadding)
@@ -280,16 +280,10 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         // Account for padding
         self.usableHeight = screenHeight - topPadding - bottomPadding
         self.usableWidth = screenWidth - leftPadding - rightPadding
-        print("Usable width")
-        print(self.usableWidth)
         
         // The button images
         // It's too costly to do the re-rendering every time, so we just do it once
-        print("Button fraction")
-        print(self.buttonFraction)
         self.imageWidth = max(self.buttonFraction * self.usableWidth, CGFloat(30))
-        print("Image width")
-        print(self.imageWidth)
         self.imageHeight = self.imageWidth
         self.starEmpty = UIImage(named: "star_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
         self.starFilled = UIImage(named: "star_filled.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
@@ -615,11 +609,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         })
         
         let width = spellTable.frame.width
-        print(width)
-        print(self.buttonFraction)
-        print(self.imageWidth)
-        print(width - 3 * self.imageWidth - 30)
-        print(UIScreen.main.bounds.width)
         NSLayoutConstraint.activate([
             cell.nameLabel.widthAnchor.constraint(equalToConstant: width - 3 * self.imageWidth - 30)
         ])
@@ -629,8 +618,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
             button in
             return button?.widthAnchor.constraint(equalToConstant: self.imageWidth)
         }))
-        print(cell.knownButton.frame)
-        print("======")
     }
     
     private func makeTargetedPreview(for configuration: UIContextMenuConfiguration, backgroundColor: UIColor? = nil) -> UITargetedPreview? {

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -95,8 +95,8 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     let bottomPaddingFraction = CGFloat(0.01)
     
     // Usable height and width
-    static var usableHeight = UIScreen.main.bounds.height
-    static var usableWidth = UIScreen.main.bounds.width
+    var usableHeight = UIScreen.main.bounds.height
+    var usableWidth = UIScreen.main.bounds.width
     
     // The navigation bar and its items
     @IBOutlet var navBar: UINavigationItem!
@@ -109,15 +109,15 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     
     // The button images
     // It's too costly to do the re-rendering every time, so we just do it once
-    static let buttonFraction = oniPad ? CGFloat(0.04) : CGFloat(0.09)
-    static let imageWidth = max(ViewController.buttonFraction * ViewController.usableWidth, CGFloat(30))
-    static let imageHeight = ViewController.imageWidth
-    static let starEmpty = UIImage(named: "star_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: ViewController.imageWidth, height: ViewController.imageHeight)
-    static let starFilled = UIImage(named: "star_filled.png")?.withRenderingMode(.alwaysOriginal).resized(width: ViewController.imageWidth, height: ViewController.imageHeight)
-    static let wandEmpty = UIImage(named: "wand_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: ViewController.imageWidth, height: ViewController.imageHeight)
-    static let wandFilled = UIImage(named: "wand_filled.png")?.withRenderingMode(.alwaysOriginal).resized(width: ViewController.imageWidth, height: ViewController.imageHeight)
-    static let bookEmpty = UIImage(named: "book_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: ViewController.imageWidth, height: ViewController.imageHeight)
-    static let bookFilled = UIImage(named: "book_filled.png")?.withRenderingMode(.alwaysOriginal).resized(width: ViewController.imageWidth, height: ViewController.imageHeight)
+    var buttonFraction: CGFloat!
+    var imageWidth: CGFloat!
+    var imageHeight: CGFloat!
+    var starEmpty: UIImage!
+    var starFilled: UIImage!
+    var wandEmpty: UIImage!
+    var wandFilled: UIImage!
+    var bookEmpty: UIImage!
+    var bookFilled: UIImage!
     
     // What to do when the search button is pressed
     @IBAction func searchButtonPressed(_ sender: Any) {
@@ -129,6 +129,11 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        // Set the sizes of the container views (there are no other top level elements)
+        let screenRect = UIScreen.main.bounds
+        setContainerDimensions(screenWidth: screenRect.size.width, screenHeight: screenRect.size.height)
+        
         store.subscribe(self) {
             $0.select {
                 ($0.profile, $0.profile?.sortFilterStatus, $0.profile?.spellFilterStatus, $0.currentSpellList, $0.dirtySpellIDs)
@@ -193,10 +198,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         // This stuff isn't in viewDidLoad so that it can access the necessary subviews
         // as this calls some subview methods as well as sets dimensions
         if !firstAppearance { return }
-        
-        // Set the sizes of the container views (there are no other top level elements)
-        let screenRect = UIScreen.main.bounds
-        setContainerDimensions(screenWidth: screenRect.size.width, screenHeight: screenRect.size.height)
         
         // Dismiss keyboard when not in the search field
         //let tapper = UITapGestureRecognizer(target: self, action: #selector(endEditing))
@@ -268,6 +269,8 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     // This function sets the sizes of the top-level container views
     func setContainerDimensions(screenWidth: CGFloat, screenHeight: CGFloat) {
         
+        self.buttonFraction = oniPad ? CGFloat(0.04) : CGFloat(0.09)
+
         // Get the padding sizes
         let leftPadding = max(min(leftPaddingFraction * screenWidth, maxHorizPadding), minHorizPadding)
         let rightPadding = max(min(rightPaddingFraction * screenWidth, maxHorizPadding), minHorizPadding)
@@ -275,9 +278,27 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         let bottomPadding = max(min(bottomPaddingFraction * screenHeight, maxBotPadding), minBotPadding)
         
         // Account for padding
-        ViewController.usableHeight = screenHeight - topPadding - bottomPadding
-        ViewController.usableWidth = screenWidth - leftPadding - rightPadding
+        self.usableHeight = screenHeight - topPadding - bottomPadding
+        self.usableWidth = screenWidth - leftPadding - rightPadding
+        print("Usable width")
+        print(self.usableWidth)
         
+        // The button images
+        // It's too costly to do the re-rendering every time, so we just do it once
+        print("Button fraction")
+        print(self.buttonFraction)
+        self.imageWidth = max(self.buttonFraction * self.usableWidth, CGFloat(30))
+        print("Image width")
+        print(self.imageWidth)
+        self.imageHeight = self.imageWidth
+        self.starEmpty = UIImage(named: "star_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
+        self.starFilled = UIImage(named: "star_filled.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
+        self.wandEmpty = UIImage(named: "wand_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
+        self.wandFilled = UIImage(named: "wand_filled.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
+        self.bookEmpty = UIImage(named: "book_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
+        self.bookFilled = UIImage(named: "book_filled.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
+        
+        spellTable.reloadData()
     }
     
     override func didReceiveMemoryWarning() {
@@ -297,8 +318,8 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     // But for the moment, the SpellDataCell change doesn't work correctly, and so rotation is disabled
     override func viewWillTransition(to size: CGSize,
                                      with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
         setContainerDimensions(screenWidth: size.width, screenHeight: size.height)
+        super.viewWillTransition(to: size, with: coordinator)
     }
     
     // Until the issue with the SpellDataCell sizing is fixed, let's disable rotation
@@ -568,12 +589,12 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         }
         
         // Set the button images
-        cell.favoriteButton.setTrueImage(image: ViewController.starFilled!)
-        cell.favoriteButton.setFalseImage(image: ViewController.starEmpty!)
-        cell.preparedButton.setTrueImage(image: ViewController.wandFilled!)
-        cell.preparedButton.setFalseImage(image: ViewController.wandEmpty!)
-        cell.knownButton.setTrueImage(image: ViewController.bookFilled!)
-        cell.knownButton.setFalseImage(image: ViewController.bookEmpty!)
+        cell.favoriteButton.setTrueImage(image: self.starFilled!)
+        cell.favoriteButton.setFalseImage(image: self.starEmpty!)
+        cell.preparedButton.setTrueImage(image: self.wandFilled!)
+        cell.preparedButton.setFalseImage(image: self.wandEmpty!)
+        cell.knownButton.setTrueImage(image: self.bookFilled!)
+        cell.knownButton.setFalseImage(image: self.bookEmpty!)
         
         // Set the button statuses
         let sfs = store.state.profile?.spellFilterStatus ?? SpellFilterStatus()
@@ -594,15 +615,22 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         })
         
         let width = spellTable.frame.width
+        print(width)
+        print(self.buttonFraction)
+        print(self.imageWidth)
+        print(width - 3 * self.imageWidth - 30)
+        print(UIScreen.main.bounds.width)
         NSLayoutConstraint.activate([
-            cell.nameLabel.widthAnchor.constraint(equalToConstant: width - 3 * ViewController.imageWidth - 30)
+            cell.nameLabel.widthAnchor.constraint(equalToConstant: width - 3 * self.imageWidth - 30)
         ])
 
         let buttons = [cell.favoriteButton, cell.preparedButton, cell.knownButton]
         NSLayoutConstraint.activate(buttons.compactMap({
             button in
-            return button?.widthAnchor.constraint(equalToConstant: ViewController.imageWidth)
+            return button?.widthAnchor.constraint(equalToConstant: self.imageWidth)
         }))
+        print(cell.knownButton.frame)
+        print("======")
     }
     
     private func makeTargetedPreview(for configuration: UIContextMenuConfiguration, backgroundColor: UIColor? = nil) -> UITargetedPreview? {

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -130,10 +130,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        // Set the sizes of the container views (there are no other top level elements)
-        let screenRect = UIScreen.main.bounds
-        setContainerDimensions(screenWidth: screenRect.size.width, screenHeight: screenRect.size.height)
-        
         store.subscribe(self) {
             $0.select {
                 ($0.profile, $0.profile?.sortFilterStatus, $0.profile?.spellFilterStatus, $0.currentSpellList, $0.dirtySpellIDs)
@@ -259,11 +255,14 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         
         // The view has appeared, so we can set firstAppearance to false
         firstAppearance = false
-        
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+                
+        // Set the sizes of the container views (there are no other top level elements)
+        let screenRect = UIScreen.main.bounds
+        setContainerDimensions(screenWidth: screenRect.size.width, screenHeight: screenRect.size.height)
     }
     
     // This function sets the sizes of the top-level container views
@@ -283,7 +282,9 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         
         // The button images
         // It's too costly to do the re-rendering every time, so we just do it once
-        self.imageWidth = max(self.buttonFraction * self.usableWidth, CGFloat(30))
+        // self.imageWidth = max(self.buttonFraction * self.usableWidth, CGFloat(30))
+        
+        self.imageWidth = oniPad ? CGFloat(40.5) : CGFloat(30.5)
         self.imageHeight = self.imageWidth
         self.starEmpty = UIImage(named: "star_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
         self.starFilled = UIImage(named: "star_filled.png")?.withRenderingMode(.alwaysOriginal).resized(width: self.imageWidth, height: self.imageHeight)
@@ -312,8 +313,8 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     // But for the moment, the SpellDataCell change doesn't work correctly, and so rotation is disabled
     override func viewWillTransition(to size: CGSize,
                                      with coordinator: UIViewControllerTransitionCoordinator) {
-        setContainerDimensions(screenWidth: size.width, screenHeight: size.height)
         super.viewWillTransition(to: size, with: coordinator)
+        setContainerDimensions(screenWidth: size.width, screenHeight: size.height)
     }
     
     // Until the issue with the SpellDataCell sizing is fixed, let's disable rotation
@@ -625,6 +626,10 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         NSLayoutConstraint.activate(buttons.compactMap({
             button in
             return button?.widthAnchor.constraint(equalToConstant: self.imageWidth)
+        }))
+        NSLayoutConstraint.activate(buttons.compactMap({
+            button in
+            return button?.heightAnchor.constraint(equalToConstant: self.imageHeight)
         }))
     }
     

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -109,7 +109,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     
     // The button images
     // It's too costly to do the re-rendering every time, so we just do it once
-    static let buttonFraction = CGFloat(0.09)
+    static let buttonFraction = oniPad ? CGFloat(0.04) : CGFloat(0.09)
     static let imageWidth = max(ViewController.buttonFraction * ViewController.usableWidth, CGFloat(30))
     static let imageHeight = ViewController.imageWidth
     static let starEmpty = UIImage(named: "star_empty.png")?.withRenderingMode(.alwaysOriginal).resized(width: ViewController.imageWidth, height: ViewController.imageHeight)

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -429,7 +429,12 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         navigationItem.titleView = searchBar
         searchBar.alpha = 0
         navigationItem.setLeftBarButton(nil, animated: true)
-        navigationItem.setRightBarButtonItems(nil, animated: true)
+        if oniPad {
+            let cancelButton = UIBarButtonItem(title: "Cancel", style: .plain, target: self, action: #selector(iPadSearchBarCancelButtonClicked))
+            navigationItem.setRightBarButtonItems([cancelButton], animated: true)
+        } else {
+            navigationItem.setRightBarButtonItems(nil, animated: true)
+        }
         self.searchBar.alpha = 1
         self.searchBar.becomeFirstResponder()
 //        UIView.animate(withDuration: 0.5, animations: {
@@ -459,6 +464,9 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         return toClose
     }
 
+    @objc func iPadSearchBarCancelButtonClicked() {
+        searchBarCancelButtonClicked(self.searchBar)
+    }
 
     // MARK: UISearchBarDelegate
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {

--- a/Spellbook/ViewController.swift
+++ b/Spellbook/ViewController.swift
@@ -592,6 +592,17 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         cell.knownButton.setCallback({
             store.dispatch(TogglePropertyAction(spell: cell.spell, property: .Known, markDirty: false))
         })
+        
+        let width = spellTable.frame.width
+        NSLayoutConstraint.activate([
+            cell.nameLabel.widthAnchor.constraint(equalToConstant: width - 3 * ViewController.imageWidth - 30)
+        ])
+
+        let buttons = [cell.favoriteButton, cell.preparedButton, cell.knownButton]
+        NSLayoutConstraint.activate(buttons.compactMap({
+            button in
+            return button?.widthAnchor.constraint(equalToConstant: ViewController.imageWidth)
+        }))
     }
     
     private func makeTargetedPreview(for configuration: UIContextMenuConfiguration, backgroundColor: UIColor? = nil) -> UITargetedPreview? {

--- a/Spellbook/iOSUtils.swift
+++ b/Spellbook/iOSUtils.swift
@@ -12,11 +12,14 @@ import Foundation
 let iOSNSFoundationVersion = NSFoundationVersionNumber
 let iOSVersion = Version.fromString(UIDevice.current.systemVersion) ?? Version(major: 0, minor: 0, patch: 0)
 
-// The iPhone version
-let iPhoneVersion = UIDevice.current.model
+// The device version
+let deviceVersion = UIDevice.current.model
 
 // The current version number of the app
 let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") ?? "0"
 
 // The current build number of the app
 let appBuild = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") ?? "0"
+
+// Are we on an iPad?
+let oniPad = UIDevice.current.userInterfaceIdiom == .pad


### PR DESCRIPTION
This PR adds iPad as a targeted device family and makes some adjustments to some pieces of the app layout to accommodate the largest screen size.

Ultimately I'd like to have it set up so that iPads get a master/detail layout while phones get the fullscreen table/slide-out spell window, like in the Android version. That's a more involved update that can wait until later, but this is still a marked improvement over the current state of things - currently, on an iPad, the app window has the aspect ratio of a phone.