### PR TITLE
Add CI step to display Swift version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,7 @@ jobs:
       uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: '16.2'
+    - name: Check Swift version
+      run: swift --version
     - name: Run tests
       run: xcodebuild test -scheme Spellbook -project Spellbook.xcodeproj -destination 'platform=iOS Simulator,name=${{ matrix.device }},OS=${{ matrix.os }}' | xcpretty && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Part of the issue that was fixed in #64 was the fact that I hadn't realized that the CI was still using Swift 5. This is determined by the XCode version that we're using, but it's rather opaque, so this PR adds a CI step to display the current Swift version.